### PR TITLE
when Jwk.generate_for_alg is called and a subclass reimplements this classmethod, it's called instead of .generate

### DIFF
--- a/jwskate/jwk/base.py
+++ b/jwskate/jwk/base.py
@@ -1039,6 +1039,11 @@ class Jwk(BaseJsonDict):
                 if issubclass(jwk_class, BaseAESEncryptionAlg):
                     kwargs.setdefault("key_size", alg_class.key_size)
 
+                # SymmetricJwk has also implemented generate_for_alg, without this would be defaults ignored
+                reimplemented_in_child = getattr(jwk_class, 'generate_for_alg', None)
+                if reimplemented_in_child and reimplemented_in_child != getattr(cls, 'generate_for_alg'):
+                    return jwk_class.generate_for_alg(alg=alg, **kwargs)
+
                 return jwk_class.generate(alg=alg, **kwargs)
             except UnsupportedAlg:
                 continue


### PR DESCRIPTION
when I tried to call

```
from jwskate import Jwk, Jwt
hmac_private_jwk = Jwk.generate_for_alg(alg="HS512")
```

I found out that extremely short key is generated - I found out that SymmetricJwk.generate_for_alg() method is ignored and because of that key_size is set to 128