### PR TITLE
more convenience methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     - id: trailing-whitespace
       args: [--markdown-linebreak-ext=md]
@@ -21,20 +21,18 @@ repos:
       - --in-place
       - --wrap-summaries=100
       - --wrap-descriptions=100
--   repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-    - id: black
 -   repo: https://github.com/asottile/blacken-docs
     rev: 1.16.0
     hooks:
         - id: blacken-docs
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.11
     hooks:
         - id: ruff
+          args: [ --fix ]
+        -   id: ruff-format
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.8.0
     hooks:
     -   id: mypy
         args:
@@ -48,3 +46,4 @@ repos:
             - pytest-mypy==0.10.3
             - binapy==0.7.0
             - freezegun==1.2.2
+            - jwcrypto==1.5.0

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Now let's sign a JWT with the standardized lifetime, subject, audience and ID cl
 from jwskate import Jwk, JwtSigner
 
 private_jwk = Jwk.generate(alg="ES256")
-signer = JwtSigner(issuer="https://myissuer.com", jwk=private_jwk)
+signer = JwtSigner(issuer="https://myissuer.com", key=private_jwk)
 jwt = signer.sign(
     subject="some_sub",
     audience="some_aud",

--- a/README.md
+++ b/README.md
@@ -18,18 +18,21 @@ from jwskate import Jwk
 
 # Let's generate a random private key, to use with alg 'RS256'.
 # Based on that alg, jwskate knows it must be an RSA key.
-# RSA keys can be of variable size, so let's pass the requested key size as parameter
+# RSA keys can be of any size, so let's pass the requested key size as parameter
 rsa_private_jwk = Jwk.generate(alg="RS256", key_size=2048)
 
 data = b"Signing is easy!"  # we will sign this
 signature = rsa_private_jwk.sign(data)  # done!
 
+print(signature)
+# b'-\xe89\x81\xc4\xb9.G\x11\xa6\x93/dm\xf0\xc8\x0f\xd....'
+
 # now extract the public key, and verify the signature with it
 rsa_public_jwk = rsa_private_jwk.public_jwk()
 assert rsa_public_jwk.verify(data, signature)
 
-# let's see what a Jwk looks like:
-assert isinstance(rsa_private_jwk, dict)  # Jwk are dict
+# let's see what a `Jwk` looks like:
+assert isinstance(rsa_private_jwk, dict)  # Jwk are dict subclasses
 
 print(rsa_private_jwk.with_usage_parameters())
 ```
@@ -98,7 +101,7 @@ assert jwt.verify_signature(private_jwk.public_jwk(), alg="ES256")
 # or with `alg` or `algs` params, and will ignore the 'alg' that is set in the JWT, for security reasons.
 ```
 
-Now let's sign a JWT with the standardised lifetime, subject, audience and ID claims, plus arbitrary custom claims:
+Now let's sign a JWT with the standardized lifetime, subject, audience and ID claims, plus arbitrary custom claims:
 
 ```python
 from jwskate import Jwk, JwtSigner
@@ -114,7 +117,7 @@ jwt = signer.sign(
 print(jwt.claims)
 ```
 
-The generated JWT will include the standardised claims (`iss`, `aud`, `sub`, `iat`, `exp` and `jti`),
+The generated JWT will include the standardized claims (`iss`, `aud`, `sub`, `iat`, `exp` and `jti`),
 together with the `extra_claims` provided to `.sign()`:
 
 ```
@@ -163,17 +166,30 @@ together with the `extra_claims` provided to `.sign()`:
 | `RS256`         | RSASSA-PKCS1-v1_5 using SHA-256                  | `RSA`    | [RFC7518, Section 3.3]             |                                |
 | `RS384`         | RSASSA-PKCS1-v1_5 using SHA-384                  | `RSA`    | [RFC7518, Section 3.3]             |                                |
 | `RS512`         | RSASSA-PKCS1-v1_5 using SHA-512                  | `RSA`    | [RFC7518, Section 3.3]             |                                |
-| `ES256`         | ECDSA using P-256 and SHA-256                    | `EC`     | [RFC7518, Section 3.4]             |                                |
-| `ES384`         | ECDSA using P-384 and SHA-384                    | `EC`     | [RFC7518, Section 3.4]             |                                |
-| `ES512`         | ECDSA using P-521 and SHA-512                    | `EC`     | [RFC7518, Section 3.4]             |                                |
 | `PS256`         | RSASSA-PSS using SHA-256 and MGF1 with SHA-256   | `RSA`    | [RFC7518, Section 3.5]             |                                |
 | `PS384`         | RSASSA-PSS using SHA-384 and MGF1 with SHA-384   | `RSA`    | [RFC7518, Section 3.5]             |                                |
 | `PS512`         | RSASSA-PSS using SHA-512 and MGF1 with SHA-512   | `RSA`    | [RFC7518, Section 3.5]             |                                |
-| `EdDSA`         | EdDSA signature algorithms                       | `OKP`    | [RFC8037, Section 3.1]             | Ed2219 and Ed448 are supported |
+| `ES256`         | ECDSA using P-256 and SHA-256                    | `EC`     | [RFC7518, Section 3.4]             |                                |
+| `ES384`         | ECDSA using P-384 and SHA-384                    | `EC`     | [RFC7518, Section 3.4]             |                                |
+| `ES512`         | ECDSA using P-521 and SHA-512                    | `EC`     | [RFC7518, Section 3.4]             |                                |
 | `ES256K`        | ECDSA using secp256k1 curve and SHA-256          | `EC`     | [RFC8812, Section 3.2]             |                                |
+| `EdDSA`         | EdDSA signature algorithms                       | `OKP`    | [RFC8037, Section 3.1]             | Ed2219 and Ed448 are supported |
 | `HS1`           | HMAC using SHA-1                                 | `oct`    | https://www.w3.org/TR/WebCryptoAPI | Validation Only                |
-| `RS1`           | RSASSA-PKCS1-v1_5 with SHA-1                     | `oct`    | https://www.w3.org/TR/WebCryptoAPI | Validation Only                |
+| `RS1`           | RSASSA-PKCS1-v1_5 with SHA-1                     | `RSA`    | https://www.w3.org/TR/WebCryptoAPI | Validation Only                |
 | `none`          | No digital signature or MAC performed            |          | [RFC7518, Section 3.6]             | Not usable by mistake          |
+
+### Supported Encryption algorithms
+
+
+| Signature Alg   | Description                                                 | Reference                |
+|-----------------|-------------------------------------------------------------|--------------------------|
+| `A128CBC-HS256` | AES_128_CBC_HMAC_SHA_256 authenticated encryption algorithm | [RFC7518, Section 5.2.3] |
+| `A192CBC-HS384` | AES_192_CBC_HMAC_SHA_384 authenticated encryption algorithm | [RFC7518, Section 5.2.4] |
+| `A256CBC-HS512` | AES_256_CBC_HMAC_SHA_512 authenticated encryption algorithm | [RFC7518, Section 5.2.5] |
+| `A128GCM`       | AES GCM using 128-bit key                                   | [RFC7518, Section 5.3]   |
+| `A192GCM`       | AES GCM using 192-bit key                                   | [RFC7518, Section 5.3]   |
+| `A256GCM`       | AES GCM using 256-bit key                                   | [RFC7518, Section 5.3]   |
+
 
 ### Supported Key Management algorithms
 
@@ -200,17 +216,7 @@ together with the `extra_claims` provided to `.sign()`:
 | `PBES2-HS384+A192KW` | PBES2 with HMAC SHA-384 and "A192KW" wrapping  | `password`  | [RFC7518, Section 4.8]             |             |
 | `PBES2-HS512+A256KW` | PBES2 with HMAC SHA-512 and "A256KW" wrapping  | `password`  | [RFC7518, Section 4.8]             |             |
 
-### Supported Encryption algorithms
 
-
-| Signature Alg | Description                                                 | Reference                |
-| ------------- | ----------------------------------------------------------- | ------------------------ |
-| `A128CBC-HS256` | AES_128_CBC_HMAC_SHA_256 authenticated encryption algorithm | [RFC7518, Section 5.2.3] |
-| `A192CBC-HS384` | AES_192_CBC_HMAC_SHA_384 authenticated encryption algorithm | [RFC7518, Section 5.2.4] |
-| `A256CBC-HS512` | AES_256_CBC_HMAC_SHA_512 authenticated encryption algorithm | [RFC7518, Section 5.2.5] |
-| `A128GCM`       | AES GCM using 128-bit key                                   | [RFC7518, Section 5.3]   |
-| `A192GCM`       | AES GCM using 192-bit key                                   | [RFC7518, Section 5.3]   |
-| `A256GCM`       | AES GCM using 256-bit key                                   | [RFC7518, Section 5.3]   |
 
 ### Supported Elliptic Curves
 
@@ -220,13 +226,13 @@ together with the `extra_claims` provided to `.sign()`:
 | `P-256`     | P-256 Curve                           | `EC`     | signature, encryption | [RFC7518, Section 6.2.1.1] |
 | `P-384`     | P-384 Curve                           | `EC`     | signature, encryption | [RFC7518, Section 6.2.1.1] |
 | `P-521`     | P-521 Curve                           | `EC`     | signature, encryption | [RFC7518, Section 6.2.1.1] |
+| `secp256k1` | SECG secp256k1 curve                  | `EC`     | signature, encryption | [RFC8812, Section 3.1]     |
 | `Ed25519`   | Ed25519 signature algorithm key pairs | `OKP`    | signature             | [RFC8037, Section 3.1]     |
 | `Ed448`     | Ed448 signature algorithm key pairs   | `OKP`    | signature             | [RFC8037, Section 3.1]     |
 | `X25519`    | X25519 function key pairs             | `OKP`    | encryption            | [RFC8037, Section 3.2]     |
 | `X448`      | X448 function key pairs               | `OKP`    | encryption            | [RFC8037, Section 3.2]     |
-| `secp256k1` | SECG secp256k1 curve                  | `EC`     | signature, encryption | [RFC8812, Section 3.1]     |
 
-## Why a new lib ?
+## Why a new lib?
 
 There are already multiple modules implementing JOSE and Json Web Crypto related specifications in Python. However, I
 have been dissatisfied by all of them so far, so I decided to come up with my own module.

--- a/jwskate/__init__.py
+++ b/jwskate/__init__.py
@@ -9,6 +9,7 @@ for convenience, you can import any class or component directly from the root
 provides a set of convenient wrappers around the `cryptography` module.
 
 """
+
 from __future__ import annotations
 
 __author__ = """Guillaume Pujol"""

--- a/jwskate/__init__.py
+++ b/jwskate/__init__.py
@@ -98,12 +98,11 @@ from .jwk import (
     select_alg_classes,
     to_jwk,
 )
-from .jws import InvalidJws, JwsCompact, JwsJsonFlat, JwsJsonGeneral, JwsSignature
+from .jws import InvalidJws, InvalidSignature, JwsCompact, JwsJsonFlat, JwsJsonGeneral, JwsSignature
 from .jwt import (
     ExpiredJwt,
     InvalidClaim,
     InvalidJwt,
-    InvalidSignature,
     Jwt,
     JwtSigner,
     JwtVerifier,

--- a/jwskate/enums.py
+++ b/jwskate/enums.py
@@ -3,6 +3,7 @@
 See [IANA JOSE](https://www.iana.org/assignments/jose/jose.xhtml).
 
 """
+
 from __future__ import annotations
 
 

--- a/jwskate/jwa/__init__.py
+++ b/jwskate/jwa/__init__.py
@@ -7,6 +7,7 @@ cryptographic operations as methods. The cryptographic operations themselves are
 [RFC7518]: https://www.rfc-editor.org/rfc/rfc7518
 
 """
+
 from __future__ import annotations
 
 from .base import (

--- a/jwskate/jwa/base.py
+++ b/jwskate/jwa/base.py
@@ -1,4 +1,5 @@
 """This module implement base classes for the algorithms defined in JWA."""
+
 from __future__ import annotations
 
 from contextlib import contextmanager

--- a/jwskate/jwa/ec.py
+++ b/jwskate/jwa/ec.py
@@ -1,4 +1,5 @@
 """This module contains classes that describe Elliptic Curves as described in RFC7518."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/jwskate/jwa/encryption/__init__.py
+++ b/jwskate/jwa/encryption/__init__.py
@@ -1,4 +1,5 @@
 """This module exposes the Encryption algorithms that are available in `jwskate`."""
+
 from __future__ import annotations
 
 from .aescbchmac import A128CBC_HS256, A192CBC_HS384, A256CBC_HS512

--- a/jwskate/jwa/encryption/aescbchmac.py
+++ b/jwskate/jwa/encryption/aescbchmac.py
@@ -1,4 +1,5 @@
 """This module implements AES-CBC with HMAC-SHA based Encryption algorithms."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes

--- a/jwskate/jwa/encryption/aesgcm.py
+++ b/jwskate/jwa/encryption/aesgcm.py
@@ -1,4 +1,5 @@
 """This module implements AES-GCM based encryption algorithms."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes

--- a/jwskate/jwa/key_mgmt/__init__.py
+++ b/jwskate/jwa/key_mgmt/__init__.py
@@ -1,4 +1,5 @@
 """This module exposes all Key Management algorithms available in `jwskate`."""
+
 from __future__ import annotations
 
 from .aesgcmkw import A128GCMKW, A192GCMKW, A256GCMKW, BaseAesGcmKeyWrap

--- a/jwskate/jwa/key_mgmt/aesgcmkw.py
+++ b/jwskate/jwa/key_mgmt/aesgcmkw.py
@@ -1,4 +1,5 @@
 """This module implements AES-GCM based Key Management algorithms."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes

--- a/jwskate/jwa/key_mgmt/aeskw.py
+++ b/jwskate/jwa/key_mgmt/aeskw.py
@@ -1,4 +1,5 @@
 """This module implements AES based Key Management algorithms."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes

--- a/jwskate/jwa/key_mgmt/dir.py
+++ b/jwskate/jwa/key_mgmt/dir.py
@@ -1,4 +1,5 @@
 """This module implements direct use of a shared symmetric key as Key Management algorithm."""
+
 from __future__ import annotations
 
 from binapy import BinaPy

--- a/jwskate/jwa/key_mgmt/ecdh.py
+++ b/jwskate/jwa/key_mgmt/ecdh.py
@@ -1,4 +1,5 @@
 """This module implements Elliptic Curve Diffie-Hellman based Key Management algorithms."""
+
 from __future__ import annotations
 
 from typing import Any, SupportsBytes, Union
@@ -65,8 +66,8 @@ class EcdhEs(
     @classmethod
     def ecdh(
         cls,
-        private_key: (ec.EllipticCurvePrivateKey | x25519.X25519PrivateKey | x448.X448PrivateKey),
-        public_key: (ec.EllipticCurvePublicKey | x25519.X25519PublicKey | x448.X448PublicKey),
+        private_key: ec.EllipticCurvePrivateKey | x25519.X25519PrivateKey | x448.X448PrivateKey,
+        public_key: ec.EllipticCurvePublicKey | x25519.X25519PublicKey | x448.X448PublicKey,
     ) -> BinaPy:
         """Perform an Elliptic Curve Diffie-Hellman key exchange.
 
@@ -104,8 +105,8 @@ class EcdhEs(
     def derive(
         cls,
         *,
-        private_key: (ec.EllipticCurvePrivateKey | x25519.X25519PrivateKey | x448.X448PrivateKey),
-        public_key: (ec.EllipticCurvePublicKey | x25519.X25519PublicKey | x448.X448PublicKey),
+        private_key: ec.EllipticCurvePrivateKey | x25519.X25519PrivateKey | x448.X448PrivateKey,
+        public_key: ec.EllipticCurvePublicKey | x25519.X25519PublicKey | x448.X448PublicKey,
         otherinfo: bytes,
         key_size: int,
     ) -> BinaPy:
@@ -143,7 +144,7 @@ class EcdhEs(
 
     def sender_key(
         self,
-        ephemeral_private_key: (ec.EllipticCurvePrivateKey | x25519.X25519PrivateKey | x448.X448PrivateKey),
+        ephemeral_private_key: ec.EllipticCurvePrivateKey | x25519.X25519PrivateKey | x448.X448PrivateKey,
         *,
         alg: str,
         key_size: int,
@@ -175,7 +176,7 @@ class EcdhEs(
 
     def recipient_key(
         self,
-        ephemeral_public_key: (ec.EllipticCurvePublicKey | x25519.X25519PublicKey | x448.X448PublicKey),
+        ephemeral_public_key: ec.EllipticCurvePublicKey | x25519.X25519PublicKey | x448.X448PublicKey,
         *,
         alg: str,
         key_size: int,
@@ -214,7 +215,7 @@ class BaseEcdhEs_AesKw(EcdhEs):  # noqa: N801
     def wrap_key_with_epk(
         self,
         plainkey: bytes,
-        ephemeral_private_key: (ec.EllipticCurvePrivateKey | x25519.X25519PrivateKey | x448.X448PrivateKey),
+        ephemeral_private_key: ec.EllipticCurvePrivateKey | x25519.X25519PrivateKey | x448.X448PrivateKey,
         **headers: Any,
     ) -> BinaPy:
         """Wrap a key for content encryption.
@@ -234,7 +235,7 @@ class BaseEcdhEs_AesKw(EcdhEs):  # noqa: N801
     def unwrap_key_with_epk(
         self,
         cipherkey: bytes | SupportsBytes,
-        ephemeral_public_key: (ec.EllipticCurvePublicKey | x25519.X25519PublicKey | x448.X448PublicKey),
+        ephemeral_public_key: ec.EllipticCurvePublicKey | x25519.X25519PublicKey | x448.X448PublicKey,
         **headers: Any,
     ) -> BinaPy:
         """Unwrap a key for content decryption.

--- a/jwskate/jwa/key_mgmt/pbes2.py
+++ b/jwskate/jwa/key_mgmt/pbes2.py
@@ -1,4 +1,5 @@
 """This module implements password-based Key Management Algorithms relying on PBES2."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes

--- a/jwskate/jwa/key_mgmt/rsa.py
+++ b/jwskate/jwa/key_mgmt/rsa.py
@@ -1,4 +1,5 @@
 """This module implements RSA based Key Management algorithms."""
+
 from __future__ import annotations
 
 from typing import Any, SupportsBytes

--- a/jwskate/jwa/okp.py
+++ b/jwskate/jwa/okp.py
@@ -4,6 +4,7 @@
 : https: //www.rfc-editor.org/rfc/rfc8037.html
 
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -22,7 +23,8 @@ class PublicKeyProtocol(Protocol):
         self,
         encoding: serialization.Encoding,
         format: serialization.PublicFormat,  # noqa: A002
-    ) -> bytes: ...
+    ) -> bytes:
+        ...
 
 
 @runtime_checkable
@@ -34,7 +36,8 @@ class PrivateKeyProtocol(Protocol):
         encoding: serialization.Encoding,
         format: serialization.PrivateFormat,  # noqa: A002
         encryption_algorithm: serialization.KeySerializationEncryption,
-    ) -> bytes: ...
+    ) -> bytes:
+        ...
 
     def public_key(self) -> PublicKeyProtocol:  # noqa: D102
         ...

--- a/jwskate/jwa/signature/__init__.py
+++ b/jwskate/jwa/signature/__init__.py
@@ -1,4 +1,5 @@
 """This module exposes all the Signature algorithms available from `jwskate`."""
+
 from __future__ import annotations
 
 from .ec import ES256, ES256K, ES384, ES512, BaseECSignatureAlg

--- a/jwskate/jwa/signature/ec.py
+++ b/jwskate/jwa/signature/ec.py
@@ -1,4 +1,5 @@
 """This module implement Elliptic Curve signature algorithms."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes

--- a/jwskate/jwa/signature/eddsa.py
+++ b/jwskate/jwa/signature/eddsa.py
@@ -1,4 +1,5 @@
 """This module implements the Edwards-curve Digital Signature Algorithm (EdDSA)."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes, Union

--- a/jwskate/jwa/signature/hmac.py
+++ b/jwskate/jwa/signature/hmac.py
@@ -1,4 +1,5 @@
 """This module implements HMAC based signature algorithms."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes

--- a/jwskate/jwa/signature/rsa.py
+++ b/jwskate/jwa/signature/rsa.py
@@ -1,4 +1,5 @@
 """This module implements RSA signature algorithms."""
+
 from __future__ import annotations
 
 from typing import SupportsBytes

--- a/jwskate/jwe/__init__.py
+++ b/jwskate/jwe/__init__.py
@@ -4,6 +4,7 @@
 : https: //www.rfc-editor.org/rfc/rfc7516
 
 """
+
 from __future__ import annotations
 
 from .compact import InvalidJwe, JweCompact

--- a/jwskate/jwe/compact.py
+++ b/jwskate/jwe/compact.py
@@ -224,7 +224,7 @@ separated by dots."""
         alg: str | None = None,
         algs: Iterable[str] | None = None,
     ) -> BinaPy:
-        """Decrypts this `Jwe` payload using a `Jwk`.
+        """Decrypt the payload from this JWE using a decryption key.
 
         Args:
           key: the decryption key

--- a/jwskate/jwe/compact.py
+++ b/jwskate/jwe/compact.py
@@ -1,4 +1,5 @@
 """This module implements the JWE Compact format."""
+
 from __future__ import annotations
 
 import warnings

--- a/jwskate/jwe/compact.py
+++ b/jwskate/jwe/compact.py
@@ -221,6 +221,7 @@ separated by dots."""
     def decrypt(
         self,
         key: Jwk | dict[str, Any] | Any,
+        *,
         alg: str | None = None,
         algs: Iterable[str] | None = None,
     ) -> BinaPy:

--- a/jwskate/jwk/__init__.py
+++ b/jwskate/jwk/__init__.py
@@ -1,4 +1,5 @@
 """This module implements [Json Web Key RFC7517](https://tools.ietf.org/html/rfc7517)."""
+
 from __future__ import annotations
 
 from .alg import (

--- a/jwskate/jwk/alg.py
+++ b/jwskate/jwk/alg.py
@@ -1,4 +1,5 @@
 """This module contains several utilities for algorithmic agility."""
+
 from __future__ import annotations
 
 import warnings

--- a/jwskate/jwk/base.py
+++ b/jwskate/jwk/base.py
@@ -647,7 +647,7 @@ class Jwk(BaseJsonDict):
         return list(self.ENCRYPTION_ALGORITHMS)
 
     def sign(self, data: bytes | SupportsBytes, alg: str | None = None) -> BinaPy:
-        """Sign a data using this Jwk, and return the generated signature.
+        """Sign data using this Jwk, and return the generated signature.
 
         Args:
           data: the data to sign

--- a/jwskate/jwk/base.py
+++ b/jwskate/jwk/base.py
@@ -8,6 +8,7 @@ specific key type and want to access its internal, type-dependent attributes, yo
 need to use the interface from `Jwk`.
 
 """
+
 from __future__ import annotations
 
 import warnings

--- a/jwskate/jwk/base.py
+++ b/jwskate/jwk/base.py
@@ -179,7 +179,7 @@ class Jwk(BaseJsonDict):
 
                 for jwk_class in Jwk.__subclasses__():
                     if kty == jwk_class.KTY:
-                        return super().__new__(jwk_class)  # type: ignore[type-var]
+                        return super().__new__(jwk_class)
 
                 msg = "Unsupported Key Type"
                 raise InvalidJwk(msg, kty)
@@ -188,7 +188,7 @@ class Jwk(BaseJsonDict):
                 return cls.from_json(key)
             else:
                 return cls.from_cryptography_key(key, **kwargs)
-        return super().__new__(cls, key, **kwargs)  # type: ignore[type-var]
+        return super().__new__(cls, key, **kwargs)
 
     def __init__(self, params: dict[str, Any] | Any, *, include_kid_thumbprint: bool = False):
         if isinstance(params, dict):  # this is to avoid double init due to the __new__ above

--- a/jwskate/jwk/ec.py
+++ b/jwskate/jwk/ec.py
@@ -1,4 +1,5 @@
 """This module implements JWK representing Elliptic Curve keys."""
+
 from __future__ import annotations
 
 import warnings

--- a/jwskate/jwk/jwks.py
+++ b/jwskate/jwk/jwks.py
@@ -1,4 +1,5 @@
 """This module implements Json Web Key Sets (JWKS)."""
+
 from __future__ import annotations
 
 from typing import Any, Iterable
@@ -52,7 +53,7 @@ class JwkSet(BaseJsonDict):
             a list of `Jwk`
 
         """
-        return self.get("keys", [])
+        return self.get("keys", [])  # type: ignore[no-any-return]
 
     def get_jwk_by_kid(self, kid: str) -> Jwk:
         """Return a Jwk from this JwkSet, based on its kid.

--- a/jwskate/jwk/oct.py
+++ b/jwskate/jwk/oct.py
@@ -1,4 +1,5 @@
 """This module implements JWK representing Symmetric keys."""
+
 from __future__ import annotations
 
 import warnings

--- a/jwskate/jwk/okp.py
+++ b/jwskate/jwk/okp.py
@@ -4,6 +4,7 @@
 : https: //www.rfc-editor.org/rfc/rfc8037.html
 
 """
+
 from __future__ import annotations
 
 from functools import cached_property

--- a/jwskate/jwk/rsa.py
+++ b/jwskate/jwk/rsa.py
@@ -1,4 +1,5 @@
 """This module implements JWK representing RSA keys."""
+
 from __future__ import annotations
 
 from functools import cached_property

--- a/jwskate/jws/__init__.py
+++ b/jwskate/jws/__init__.py
@@ -4,6 +4,6 @@ from __future__ import annotations
 
 from .compact import InvalidJws, JwsCompact
 from .json import JwsJsonFlat, JwsJsonGeneral
-from .signature import JwsSignature
+from .signature import InvalidSignature, JwsSignature
 
-__all__ = ["InvalidJws", "JwsCompact", "JwsJsonFlat", "JwsJsonGeneral", "JwsSignature"]
+__all__ = ["InvalidJws", "InvalidSignature", "JwsCompact", "JwsJsonFlat", "JwsJsonGeneral", "JwsSignature"]

--- a/jwskate/jws/__init__.py
+++ b/jwskate/jws/__init__.py
@@ -1,4 +1,5 @@
 """This module implements JWS token handling."""
+
 from __future__ import annotations
 
 from .compact import InvalidJws, JwsCompact

--- a/jwskate/jws/compact.py
+++ b/jwskate/jws/compact.py
@@ -1,4 +1,5 @@
 """This module implements the JWS Compact format."""
+
 from __future__ import annotations
 
 from functools import cached_property

--- a/jwskate/jws/compact.py
+++ b/jwskate/jws/compact.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Iterable, Self, SupportsBytes
+from typing import TYPE_CHECKING, Any, Iterable, SupportsBytes
 
 from binapy import BinaPy
+from typing_extensions import Self
 
 from jwskate.jwk.base import Jwk, to_jwk
 from jwskate.token import BaseCompactToken

--- a/jwskate/jws/compact.py
+++ b/jwskate/jws/compact.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Iterable, SupportsBytes
+from typing import TYPE_CHECKING, Any, Iterable, Self, SupportsBytes
 
 from binapy import BinaPy
 
 from jwskate.jwk.base import Jwk, to_jwk
 from jwskate.token import BaseCompactToken
 
-from .signature import JwsSignature
+from .signature import InvalidSignature, JwsSignature
 
 if TYPE_CHECKING:
     from .json import JwsJsonFlat, JwsJsonGeneral  # pragma: no cover
@@ -149,6 +149,51 @@ class JwsCompact(BaseCompactToken):
         """
         key = to_jwk(key)
         return key.verify(self.signed_part, self.signature, alg=alg, algs=algs)
+
+    def verify(
+        self,
+        key: Jwk | dict[str, Any] | Any,
+        *,
+        alg: str | None = None,
+        algs: Iterable[str] | None = None,
+    ) -> Self:
+        """Verify this JWS signature.
+
+        This is an alternative to `.verify_signature()` that raises an exception if the signature is not
+        verified.
+
+        Args:
+          key: the Jwk to use to validate this signature
+          alg: the alg to use, if there is only 1 allowed
+          algs: the allowed algs, if here are several
+
+        Raises:
+            InvalidSignature: if the signature does not verify
+
+        Returns:
+          The same JwsCompact
+
+        Usage:
+            ```python
+            jws = JwsCompact(
+                "eyJhbGciOm51bGx9.SGVsbG8gV29ybGQh.rd61m4AQ6dOqexdZC9revgictOzRd7dmHiQ5UMa9g66BhAO8crw_E_5SkydE-PNNzRkdFdq4P2YzzM1HgfnWlw"
+            ).verify(
+                {
+                    "kty": "EC",
+                    "alg": "ES256",
+                    "crv": "P-256",
+                    "x": "T_RLrReYRPIknDpIEjLUoy7ibAbqJDfHe03mkEjI_oU",
+                    "y": "8MM4v58j8IHag6uibgC0Qn275bl9c9JR0UD0TwFgMPM",
+                }
+            )
+
+            assert jws.payload == b"Hello World!"
+            ```
+
+        """
+        if self.verify_signature(key, alg=alg, algs=algs):
+            return self
+        raise InvalidSignature(data=self, key=key, alg=alg, algs=algs)
 
     def flat_json(self, unprotected_header: Any = None) -> JwsJsonFlat:
         """Create a JWS in JSON flat format based on this Compact JWS.

--- a/jwskate/jws/compact.py
+++ b/jwskate/jws/compact.py
@@ -136,7 +136,7 @@ class JwsCompact(BaseCompactToken):
         alg: str | None = None,
         algs: Iterable[str] | None = None,
     ) -> bool:
-        """Verify the signature from this JwsCompact using a Jwk.
+        """Verify the signature from this JwsCompact using a key.
 
         Args:
           key: the Jwk to use to validate this signature

--- a/jwskate/jws/json.py
+++ b/jwskate/jws/json.py
@@ -1,4 +1,5 @@
 """This module implement the JWS JSON flat and general formats."""
+
 from __future__ import annotations
 
 from functools import cached_property

--- a/jwskate/jws/json.py
+++ b/jwskate/jws/json.py
@@ -1,4 +1,4 @@
-"""This module implement the JWS JSON flat and general formats."""
+"""This module implements the JWS JSON flat and general formats."""
 
 from __future__ import annotations
 

--- a/jwskate/jws/signature.py
+++ b/jwskate/jws/signature.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Any, Iterable, Mapping, TypeVar
+from typing import Any, Iterable, Mapping, SupportsBytes, TypeVar
 
 from binapy import BinaPy
 
 from jwskate.jwk import Jwk, to_jwk
 from jwskate.token import BaseJsonDict
+
+
+class InvalidSignature(ValueError):
+    """Raised when trying to validate a token with an invalid signature."""
+
+    def __init__(self, data: SupportsBytes, key: Any, alg: str | None, algs: Iterable[str] | None) -> None:
+        self.data = data
+        self.key = key
+        self.alg = alg
+        self.algs = algs
+
 
 S = TypeVar("S", bound="JwsSignature")
 

--- a/jwskate/jws/signature.py
+++ b/jwskate/jws/signature.py
@@ -14,9 +14,9 @@ S = TypeVar("S", bound="JwsSignature")
 
 
 class JwsSignature(BaseJsonDict):
-    """Represents a JWS Signature.
+    """Represent a JWS Signature.
 
-    A JWS Signature has
+    A JWS Signature has:
 
      - a protected header (as a JSON object)
      - a signature value (as raw data)

--- a/jwskate/jws/signature.py
+++ b/jwskate/jws/signature.py
@@ -1,4 +1,5 @@
 """This module implement JWS signatures."""
+
 from __future__ import annotations
 
 from functools import cached_property

--- a/jwskate/jwt/__init__.py
+++ b/jwskate/jwt/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .base import InvalidJwt, Jwt
-from .signed import ExpiredJwt, InvalidClaim, InvalidSignature, SignedJwt
+from .signed import ExpiredJwt, InvalidClaim, SignedJwt
 from .signer import JwtSigner
 from .verifier import JwtVerifier
 
@@ -11,7 +11,6 @@ __all__ = [
     "ExpiredJwt",
     "InvalidClaim",
     "InvalidJwt",
-    "InvalidSignature",
     "Jwt",
     "JwtSigner",
     "JwtVerifier",

--- a/jwskate/jwt/__init__.py
+++ b/jwskate/jwt/__init__.py
@@ -1,4 +1,5 @@
 """This module contains all Json Web Key (Jwk) related classes and utilities."""
+
 from __future__ import annotations
 
 from .base import InvalidJwt, Jwt

--- a/jwskate/jwt/base.py
+++ b/jwskate/jwt/base.py
@@ -246,7 +246,7 @@ class Jwt(BaseCompactToken):
 
     @classmethod
     def timestamp(cls, delta_seconds: int = 0) -> int:
-        """Return an integer timestamp that is suitable for use in Jwt tokens.
+        """Return an integer timestamp that is suitable for use in JWT tokens.
 
         Timestamps are used in particular for `iat`, `exp` and `nbf` claims.
 

--- a/jwskate/jwt/base.py
+++ b/jwskate/jwt/base.py
@@ -1,4 +1,5 @@
-"""This modules contains the `Jwt` base class."""
+"""This module contains the `Jwt` base class."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -21,7 +22,7 @@ class InvalidJwt(ValueError):
 class Jwt(BaseCompactToken):
     """Represents a Json Web Token."""
 
-    def __new__(cls, value: bytes | str, max_size: int = 16 * 1024) -> SignedJwt | JweCompact | Jwt:  # type: ignore[misc] # noqa: E501
+    def __new__(cls, value: bytes | str, max_size: int = 16 * 1024) -> SignedJwt | JweCompact | Jwt:  # type: ignore[misc]
         """Allow parsing both Signed and Encrypted JWTs.
 
         This returns the appropriate subclass or instance depending on the number of dots (.) in the serialized JWT.
@@ -188,7 +189,9 @@ class Jwt(BaseCompactToken):
           the resulting JWE token, with the signed JWT as payload
 
         """
-        return cls.sign(claims, key=sign_key, alg=sign_alg, extra_headers=sign_extra_headers).encrypt(enc_key, enc=enc, alg=enc_alg, extra_headers=enc_extra_headers)
+        return cls.sign(claims, key=sign_key, alg=sign_alg, extra_headers=sign_extra_headers).encrypt(
+            enc_key, enc=enc, alg=enc_alg, extra_headers=enc_extra_headers
+        )
 
     @classmethod
     def decrypt_nested_jwt(cls, jwe: str | JweCompact, key: Jwk | dict[str, Any] | Any) -> SignedJwt:

--- a/jwskate/jwt/base.py
+++ b/jwskate/jwt/base.py
@@ -52,6 +52,7 @@ class Jwt(BaseCompactToken):
         cls,
         claims: dict[str, Any],
         key: Jwk | dict[str, Any] | Any,
+        *,
         alg: str | None = None,
         typ: str | None = "JWT",
         extra_headers: dict[str, Any] | None = None,
@@ -95,6 +96,7 @@ class Jwt(BaseCompactToken):
         claims: dict[str, Any],
         headers: dict[str, Any],
         key: Jwk | dict[str, Any] | Any,
+        *,
         alg: str | None = None,
     ) -> SignedJwt:
         """Sign provided headers and claims with a private key and return the resulting `SignedJwt`.
@@ -130,6 +132,7 @@ class Jwt(BaseCompactToken):
     def unprotected(
         cls,
         claims: dict[str, Any],
+        *,
         typ: str | None = "JWT",
         extra_headers: dict[str, Any] | None = None,
     ) -> SignedJwt:

--- a/jwskate/jwt/signed.py
+++ b/jwskate/jwt/signed.py
@@ -11,22 +11,13 @@ from typing_extensions import Self
 
 from jwskate.jwe import JweCompact
 from jwskate.jwk import Jwk, to_jwk
+from jwskate.jws import InvalidSignature
 
 from .base import InvalidJwt, Jwt
 
 
 class ExpiredJwt(ValueError):
     """Raised when trying to validate an expired JWT token."""
-
-
-class InvalidSignature(ValueError):
-    """Raised when trying to validate a JWT with an invalid signature."""
-
-    def __init__(self, jwt: SignedJwt, key: Any, alg: str | None, algs: Iterable[str] | None):
-        self.jwt = jwt
-        self.key = key
-        self.alg = alg
-        self.algs = algs
 
 
 class InvalidClaim(ValueError):
@@ -140,7 +131,7 @@ class SignedJwt(Jwt):
         """
         if self.verify_signature(key, alg=alg, algs=algs):
             return self
-        raise InvalidSignature(jwt=self, key=key, alg=alg, algs=algs)
+        raise InvalidSignature(data=self, key=key, alg=alg, algs=algs)
 
     def is_expired(self, leeway: int = 0) -> bool | None:
         """Check if this token is expired, based on its `exp` claim.

--- a/jwskate/jwt/signed.py
+++ b/jwskate/jwt/signed.py
@@ -116,6 +116,27 @@ class SignedJwt(Jwt):
         Raises:
             InvalidSignature: if the signature does not verify.
 
+        Return:
+            the same `SignedJwt`, if the signature is verified.
+
+        Usage:
+            ```python
+            jwt = SignedJwt(
+                "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJURVNUIn0.tIUFZqEZD12odEyBWscuxc4USspdYfJKhxPN0JXVMK97SUM69HrU5MGgocyyBbx1x9yIAkV7rNjcviqwGoVvsQ"
+            ).verify(
+                {
+                    "kty": "EC",
+                    "alg": "ES256",
+                    "crv": "P-256",
+                    "x": "T_RLrReYRPIknDpIEjLUoy7ibAbqJDfHe03mkEjI_oU",
+                    "y": "8MM4v58j8IHag6uibgC0Qn275bl9c9JR0UD0TwFgMPM",
+                }
+            )
+
+            # you can now do your business with this verified JWT:
+            assert jwt.claims == {"sub": "TEST"}
+            ```
+
         """
         if self.verify_signature(key, alg=alg, algs=algs):
             return self

--- a/jwskate/jwt/signed.py
+++ b/jwskate/jwt/signed.py
@@ -1,4 +1,5 @@
 """This modules contains classes and utilities to generate and validate signed JWT."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone

--- a/jwskate/jwt/signer.py
+++ b/jwskate/jwt/signer.py
@@ -70,6 +70,7 @@ class JwtSigner:
         self,
         issuer: str,
         jwk: Jwk,
+        *,
         alg: str | None = None,
         default_lifetime: int = 60,
         default_leeway: int | None = None,
@@ -82,6 +83,7 @@ class JwtSigner:
 
     def sign(
         self,
+        *,
         subject: str | None = None,
         audience: str | Iterable[str] | None = None,
         extra_claims: dict[str, Any] | None = None,
@@ -146,6 +148,7 @@ class JwtSigner:
     @classmethod
     def with_random_key(
         cls,
+        *,
         issuer: str,
         alg: str,
         default_lifetime: int = 60,
@@ -166,10 +169,11 @@ class JwtSigner:
 
         """
         jwk = Jwk.generate_for_alg(alg, kid=kid).with_kid_thumbprint()
-        return cls(issuer, jwk, alg, default_lifetime, default_leeway)
+        return cls(issuer=issuer, key=jwk, alg=alg, default_lifetime=default_lifetime, default_leeway=default_leeway)
 
     def verifier(
         self,
+        *,
         audience: str,
         verifiers: Iterable[Callable[[SignedJwt], None]] | None = None,
         **kwargs: Any,

--- a/jwskate/jwt/signer.py
+++ b/jwskate/jwt/signer.py
@@ -23,6 +23,7 @@ assert isinstance(signer.jwk, ECJwk) and signer.jwk.is_private
 ```
 
 """
+
 from __future__ import annotations
 
 import uuid

--- a/jwskate/jwt/signer.py
+++ b/jwskate/jwt/signer.py
@@ -57,7 +57,7 @@ class JwtSigner:
 
     Args:
         issuer: the issuer string to use as `ìss` claim for signed tokens.
-        jwk: the private Jwk to use to sign tokens.
+        key: the private Jwk to use to sign tokens.
         alg: the signing alg to use to sign tokens.
         default_lifetime: the default lifetime, in seconds, to use for claim `exp`. This can be overridden
             when calling `.sign()`
@@ -68,16 +68,16 @@ class JwtSigner:
 
     def __init__(
         self,
-        issuer: str,
-        jwk: Jwk,
+        key: Jwk | Any,
         *,
+        issuer: str | None = None,
         alg: str | None = None,
         default_lifetime: int = 60,
         default_leeway: int | None = None,
     ):
         self.issuer = issuer
-        self.jwk = jwk
-        self.alg = jwk.alg or alg
+        self.jwk = Jwk(key)
+        self.alg = alg
         self.default_lifetime = default_lifetime
         self.default_leeway = default_leeway
 

--- a/jwskate/jwt/signer.py
+++ b/jwskate/jwt/signer.py
@@ -37,13 +37,13 @@ from .verifier import JwtVerifier
 
 
 class JwtSigner:
-    """A helper class to easily sign JWTs with standardised claims.
+    """A helper class to easily sign JWTs with standardized claims.
 
-    The standardised claims include:
+    The standardized claims include:
 
-       - `ìat`: issued at date
+       - `Ìat`: issued at date
        - `exp`: expiration date
-       - `nbf`: not before date:
+       - `nbf`: not before date
        - `iss`: issuer identifier
        - `sub`: subject identifier
        - `aud`: audience identifier
@@ -174,7 +174,7 @@ class JwtSigner:
         verifiers: Iterable[Callable[[SignedJwt], None]] | None = None,
         **kwargs: Any,
     ) -> JwtVerifier:
-        """Return the matching JwtVerifier, initialized with the public key."""
+        """Return the matching `JwtVerifier`, initialized with the public key."""
         return JwtVerifier(
             issuer=self.issuer,
             jwkset=self.jwk.public_jwk().as_jwks(),

--- a/jwskate/jwt/verifier.py
+++ b/jwskate/jwt/verifier.py
@@ -1,4 +1,5 @@
 """High-Level facility to verify JWT tokens signature, validity dates, issuer, audiences, etc."""
+
 from __future__ import annotations
 
 from typing import Any, Callable, Iterable

--- a/jwskate/jwt/verifier.py
+++ b/jwskate/jwt/verifier.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, Iterable
 
-from jwskate import Jwk, JwkSet
+from jwskate import InvalidSignature, Jwk, JwkSet
 
-from .signed import ExpiredJwt, InvalidClaim, InvalidSignature, SignedJwt
+from .signed import ExpiredJwt, InvalidClaim, SignedJwt
 
 
 class JwtVerifier:
@@ -103,7 +103,7 @@ class JwtVerifier:
                 if jwt.verify_signature(jwk, alg=self.alg, algs=self.algs):
                     break
             else:
-                raise InvalidSignature(jwt=jwt, key=self.jwkset, alg=self.alg, algs=self.algs)
+                raise InvalidSignature(data=jwt, key=self.jwkset, alg=self.alg, algs=self.algs)
 
         if jwt.is_expired(self.leeway):
             msg = f"Jwt token expired at {jwt.expires_at}"

--- a/jwskate/token.py
+++ b/jwskate/token.py
@@ -98,7 +98,7 @@ class BaseCompactToken:
         if kid is None or not isinstance(kid, str):
             msg = "This token doesn't have a valid 'kid' header"
             raise AttributeError(msg)
-        return kid
+        return kid  # type: ignore[no-any-return]
 
     @cached_property
     def typ(self) -> str:

--- a/jwskate/token.py
+++ b/jwskate/token.py
@@ -1,4 +1,5 @@
 """This module contains base classes for all tokens types handled by `jwskate`."""
+
 from __future__ import annotations
 
 import json
@@ -81,7 +82,7 @@ class BaseCompactToken:
         if alg is None or not isinstance(alg, str):  # pragma: no branch
             msg = "This token doesn't have a valid 'alg' header"
             raise AttributeError(msg)
-        return alg
+        return alg  # type: ignore[no-any-return]
 
     @cached_property
     def kid(self) -> str:
@@ -113,7 +114,7 @@ class BaseCompactToken:
         if typ is None or not isinstance(typ, str):  # pragma: no branch
             msg = "This token doesn't have a valid 'typ' header"
             raise AttributeError(msg)
-        return typ
+        return typ  # type: ignore[no-any-return]
 
     @cached_property
     def cty(self) -> str:
@@ -129,7 +130,7 @@ class BaseCompactToken:
         if cty is None or not isinstance(cty, str):  # pragma: no branch
             msg = "This token doesn't have a valid 'cty' header"
             raise AttributeError(msg)
-        return cty
+        return cty  # type: ignore[no-any-return]
 
     def __repr__(self) -> str:
         """Return the `str` representation of this token."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ ignore = [
     "N818", # Exception names should be named with an Error suffix
     "PLR0912", # Too many branches
     "D107", # Missing docstring in `__init__`
+    "ISC001", # Implicitly concatenated string literals on one line
 ]
 exclude = [
     "tests"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 """Unit test package for jwskate."""
+
 from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for all tests."""
+
 from __future__ import annotations
 
 import pytest
@@ -21,18 +22,16 @@ def kid() -> str:
 @pytest.fixture()
 def private_jwk(kid: str) -> Jwk:
     """Return a private Jwk, usable for signing or decryption."""
-    return Jwk(
-        {
-            "kty": "RSA",
-            "kid": kid,
-            "alg": "RS256",
-            "n": "2jgK-5aws3_fjllgnAacPkwjbz3RCeAHni1pcHvReuTgk9qEiTmXWJiSS_F20VeI1zEwFM36e836ROCyOQ8cjjaPWpdzCajWC0koY7X8MPhZbdoSptOmDBseRCyYqmeMCp8mTTOD6Cs43SiIYSMNlPuio89qjf_4u32eVF_5YqOGtwfzC4p2NUPPCxpljYpAcf2BBG1tRX1mY4WP_8zwmx3ZH7Sy0V_fXI46tzDqfRXdMhHW7ARJAnEr_EJhlMgUaM7FUQKUNpi1ZdeeLxYv44eRx9-Roy5zTG1b0yRuaKaAG3559572quOcxISZzK5Iy7BhE7zxVa9jabEl-Y1Daw",
-            "e": "AQAB",
-            "d": "XCtpsCRQ1DBBm51yqdQ88C82lEjW30Xp0cy6iVEzBKZhmPGmI1PY8gnXWQ5PMlK3sLTM6yypDNvORoNlo6YXWJYA7LGlXEIczj2DOsJmF8T9-OEwGZixvNFDcmYnwWnlA6N_CQKmR0ziQr9ZAzZMCU5Tvr7f8cRZKdAALQEwk5FYpLnEbXOBduJtY9x2kddJSCJwRaEJhx0fG_pJAO3yLUZBY20dZK8UrxDoCgB9eiZV3N4uWGt367r1MDdaxGY6l6bC1HZCHkttBuTxfSUMCgooZevdU6ThQNpFrwZNY3KoP-OksEdqMs-neecfk_AQREkubDW2VPNFnaVEa38BKQ",
-            "p": "8QNZGwUINpkuZi8l2ZfQzKVeOeNe3aQ7UW0wperM-63DFEJDRO1UyNC1n6yeo8_RxPZKSTlr6xZDoilQq23mopeF6O0ZmYz6E2VWJuma65V-A7tB-6xjqUXPlSkCNA6Ia8kMeCmNpKs0r0ijTBf_2y2GSsNH4EcP7XzcDEeJIh0",
-            "q": "58nWgg-qRorRddwKM7qhLxJnEDsnCiYhbKJrP78OfBZ-839bNRvL5D5sfjJqxcKMQidgpYZVvVNL8oDEywcC5T7kKW0HK1JUdYiX9DuI40Mv9WzXQ8B8FBjp5wV4IX6_0KgyIiyoUiKpVHBvO0YFPUYuk0Ns4H9yEws93RWwhSc",
-            "dp": "zFsLZcaphSnzVr9pd4urhqo9MBZjbMmBZnSQCE8ECe729ymMQlh-SFv3dHF4feuLsVcn-9iNceMJ6-jeNs1T_s89wxevWixYKrQFDa-MJW83T1CrDQvJ4VCJR69i5-Let43cXdLWACcO4AVWOQIsdpquQJw-SKPYlIUHS_4n_90",
-            "dq": "fP79rNnhy3TlDBgDcG3-qjHUXo5nuTNi5wCXsaLInuZKw-k0OGmrBIUdYNizd744gRxXJCxTZGvdEwOaHJrFVvcZd7WSHiyh21g0CcNpSJVc8Y8mbyUIRJZC3RC3_egqbM2na4KFqvWCN0UC1wYloSuNxmCgAFj6HYb8b5NYxBU",
-            "qi": "hxXfLYgwrfZBvZ27nrPsm6mLuoO-V2rKdOj3-YDJzf0gnVGBLl0DZbgydZ8WZmSLn2290mO_J8XY-Ss8PjLYbz3JXPDNLMJ-da3iEPKTvh6OfliM_dBxhaW8sq5afLMUR0H8NeabbWkfPz5h0W11CCBYxsyPC6CzniFYCYXfByU",
-        }
-    )
+    return Jwk({
+        "kty": "RSA",
+        "kid": kid,
+        "alg": "RS256",
+        "n": "2jgK-5aws3_fjllgnAacPkwjbz3RCeAHni1pcHvReuTgk9qEiTmXWJiSS_F20VeI1zEwFM36e836ROCyOQ8cjjaPWpdzCajWC0koY7X8MPhZbdoSptOmDBseRCyYqmeMCp8mTTOD6Cs43SiIYSMNlPuio89qjf_4u32eVF_5YqOGtwfzC4p2NUPPCxpljYpAcf2BBG1tRX1mY4WP_8zwmx3ZH7Sy0V_fXI46tzDqfRXdMhHW7ARJAnEr_EJhlMgUaM7FUQKUNpi1ZdeeLxYv44eRx9-Roy5zTG1b0yRuaKaAG3559572quOcxISZzK5Iy7BhE7zxVa9jabEl-Y1Daw",
+        "e": "AQAB",
+        "d": "XCtpsCRQ1DBBm51yqdQ88C82lEjW30Xp0cy6iVEzBKZhmPGmI1PY8gnXWQ5PMlK3sLTM6yypDNvORoNlo6YXWJYA7LGlXEIczj2DOsJmF8T9-OEwGZixvNFDcmYnwWnlA6N_CQKmR0ziQr9ZAzZMCU5Tvr7f8cRZKdAALQEwk5FYpLnEbXOBduJtY9x2kddJSCJwRaEJhx0fG_pJAO3yLUZBY20dZK8UrxDoCgB9eiZV3N4uWGt367r1MDdaxGY6l6bC1HZCHkttBuTxfSUMCgooZevdU6ThQNpFrwZNY3KoP-OksEdqMs-neecfk_AQREkubDW2VPNFnaVEa38BKQ",
+        "p": "8QNZGwUINpkuZi8l2ZfQzKVeOeNe3aQ7UW0wperM-63DFEJDRO1UyNC1n6yeo8_RxPZKSTlr6xZDoilQq23mopeF6O0ZmYz6E2VWJuma65V-A7tB-6xjqUXPlSkCNA6Ia8kMeCmNpKs0r0ijTBf_2y2GSsNH4EcP7XzcDEeJIh0",
+        "q": "58nWgg-qRorRddwKM7qhLxJnEDsnCiYhbKJrP78OfBZ-839bNRvL5D5sfjJqxcKMQidgpYZVvVNL8oDEywcC5T7kKW0HK1JUdYiX9DuI40Mv9WzXQ8B8FBjp5wV4IX6_0KgyIiyoUiKpVHBvO0YFPUYuk0Ns4H9yEws93RWwhSc",
+        "dp": "zFsLZcaphSnzVr9pd4urhqo9MBZjbMmBZnSQCE8ECe729ymMQlh-SFv3dHF4feuLsVcn-9iNceMJ6-jeNs1T_s89wxevWixYKrQFDa-MJW83T1CrDQvJ4VCJR69i5-Let43cXdLWACcO4AVWOQIsdpquQJw-SKPYlIUHS_4n_90",
+        "dq": "fP79rNnhy3TlDBgDcG3-qjHUXo5nuTNi5wCXsaLInuZKw-k0OGmrBIUdYNizd744gRxXJCxTZGvdEwOaHJrFVvcZd7WSHiyh21g0CcNpSJVc8Y8mbyUIRJZC3RC3_egqbM2na4KFqvWCN0UC1wYloSuNxmCgAFj6HYb8b5NYxBU",
+        "qi": "hxXfLYgwrfZBvZ27nrPsm6mLuoO-V2rKdOj3-YDJzf0gnVGBLl0DZbgydZ8WZmSLn2290mO_J8XY-Ss8PjLYbz3JXPDNLMJ-da3iEPKTvh6OfliM_dBxhaW8sq5afLMUR0H8NeabbWkfPz5h0W11CCBYxsyPC6CzniFYCYXfByU",
+    })

--- a/tests/test_jwa/test_encryption.py
+++ b/tests/test_jwa/test_encryption.py
@@ -1,4 +1,5 @@
 """Tests for jwskate.jwa.encryption submodule."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_jwa/test_examples.py
+++ b/tests/test_jwa/test_examples.py
@@ -1,4 +1,5 @@
 """Tests for the jwkskate.jwa submodule."""
+
 from __future__ import annotations
 
 from binapy import BinaPy
@@ -123,24 +124,20 @@ def test_aes_192_hmac_sha384() -> None:
 
 def test_ecdhes() -> None:
     """Test derived from [RFC7518](https://datatracker.ietf.org/doc/html/rfc7518#appendix-C)."""
-    alice_ephemeral_key = Jwk(
-        {
-            "kty": "EC",
-            "crv": "P-256",
-            "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
-            "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps",
-            "d": "0_NxaRPUMQoAJt50Gz8YiTr8gRTwyEaCumd-MToTmIo",
-        }
-    )
-    bob_private_key = Jwk(
-        {
-            "kty": "EC",
-            "crv": "P-256",
-            "x": "weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ",
-            "y": "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck",
-            "d": "VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw",
-        }
-    )
+    alice_ephemeral_key = Jwk({
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+        "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps",
+        "d": "0_NxaRPUMQoAJt50Gz8YiTr8gRTwyEaCumd-MToTmIo",
+    })
+    bob_private_key = Jwk({
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ",
+        "y": "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck",
+        "d": "VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw",
+    })
 
     otherinfo = EcdhEs.otherinfo(alg="A128GCM", apu=b"Alice", apv=b"Bob", key_size=128)
     alice_cek = EcdhEs.derive(

--- a/tests/test_jwa/test_key_mgmt.py
+++ b/tests/test_jwa/test_key_mgmt.py
@@ -1,4 +1,5 @@
 """Tests for jwskate.jwa.key_mgmt submodule."""
+
 from __future__ import annotations
 
 import pytest
@@ -18,7 +19,7 @@ from jwskate import BasePbes2, EcdhEs
     ],
 )
 def test_ecdhes(
-    key_gen: (type[ec.EllipticCurvePrivateKey] | type[x25519.X25519PrivateKey] | type[x448.X448PrivateKey]),
+    key_gen: type[ec.EllipticCurvePrivateKey] | type[x25519.X25519PrivateKey] | type[x448.X448PrivateKey],
 ) -> None:
     private_key = key_gen()
     sender_ecdhes = EcdhEs(private_key.public_key())

--- a/tests/test_jwa/test_signature.py
+++ b/tests/test_jwa/test_signature.py
@@ -1,4 +1,5 @@
 """Tests for jwskate.jwa.signature submodule."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_jwe.py
+++ b/tests/test_jwe.py
@@ -25,53 +25,51 @@ def test_jwe() -> None:
     alg = "RSA-OAEP"
     enc = "A256GCM"
     cek = bytes.fromhex("b1a1f480548fe1733fb403ff6b9ad4f68a076e5b702e22692f82cb2e7aea40fc")
-    jwk = Jwk(
-        {
-            "kty": "RSA",
-            "n": (
-                "oahUIoWw0K0usKNuOR6H4wkf4oBUXHTxRvgb48E-BVvxkeDNjbC4he8rUW"
-                "cJoZmds2h7M70imEVhRU5djINXtqllXI4DFqcI1DgjT9LewND8MW2Krf3S"
-                "psk_ZkoFnilakGygTwpZ3uesH-PFABNIUYpOiN15dsQRkgr0vEhxN92i2a"
-                "sbOenSZeyaxziK72UwxrrKoExv6kc5twXTq4h-QChLOln0_mtUZwfsRaMS"
-                "tPs6mS6XrgxnxbWhojf663tuEQueGC-FCMfra36C9knDFGzKsNa7LZK2dj"
-                "YgyD3JR_MB_4NUJW_TqOQtwHYbxevoJArm-L5StowjzGy-_bq6Gw"
-            ),
-            "e": "AQAB",
-            "d": (
-                "kLdtIj6GbDks_ApCSTYQtelcNttlKiOyPzMrXHeI-yk1F7-kpDxY4-WY5N"
-                "WV5KntaEeXS1j82E375xxhWMHXyvjYecPT9fpwR_M9gV8n9Hrh2anTpTD9"
-                "3Dt62ypW3yDsJzBnTnrYu1iwWRgBKrEYY46qAZIrA2xAwnm2X7uGR1hghk"
-                "qDp0Vqj3kbSCz1XyfCs6_LehBwtxHIyh8Ripy40p24moOAbgxVw3rxT_vl"
-                "t3UVe4WO3JkJOzlpUf-KTVI2Ptgm-dARxTEtE-id-4OJr0h-K-VFs3VSnd"
-                "VTIznSxfyrj8ILL6MG_Uv8YAu7VILSB3lOW085-4qE3DzgrTjgyQ"
-            ),
-            "p": (
-                "1r52Xk46c-LsfB5P442p7atdPUrxQSy4mti_tZI3Mgf2EuFVbUoDBvaRQ-"
-                "SWxkbkmoEzL7JXroSBjSrK3YIQgYdMgyAEPTPjXv_hI2_1eTSPVZfzL0lf"
-                "fNn03IXqWF5MDFuoUYE0hzb2vhrlN_rKrbfDIwUbTrjjgieRbwC6Cl0"
-            ),
-            "q": (
-                "wLb35x7hmQWZsWJmB_vle87ihgZ19S8lBEROLIsZG4ayZVe9Hi9gDVCOBm"
-                "UDdaDYVTSNx_8Fyw1YYa9XGrGnDew00J28cRUoeBB_jKI1oma0Orv1T9aX"
-                "IWxKwd4gvxFImOWr3QRL9KEBRzk2RatUBnmDZJTIAfwTs0g68UZHvtc"
-            ),
-            "dp": (
-                "ZK-YwE7diUh0qR1tR7w8WHtolDx3MZ_OTowiFvgfeQ3SiresXjm9gZ5KL"
-                "hMXvo-uz-KUJWDxS5pFQ_M0evdo1dKiRTjVw_x4NyqyXPM5nULPkcpU827"
-                "rnpZzAJKpdhWAgqrXGKAECQH0Xt4taznjnd_zVpAmZZq60WPMBMfKcuE"
-            ),
-            "dq": (
-                "Dq0gfgJ1DdFGXiLvQEZnuKEN0UUmsJBxkjydc3j4ZYdBiMRAy86x0vHCj"
-                "ywcMlYYg4yoC4YZa9hNVcsjqA3FeiL19rk8g6Qn29Tt0cj8qqyFpz9vNDB"
-                "UfCAiJVeESOjJDZPYHdHY8v1b-o-Z2X5tvLx-TCekf7oxyeKDUqKWjis"
-            ),
-            "qi": (
-                "VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7"
-                "AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3"
-                "eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
-            ),
-        }
-    )
+    jwk = Jwk({
+        "kty": "RSA",
+        "n": (
+            "oahUIoWw0K0usKNuOR6H4wkf4oBUXHTxRvgb48E-BVvxkeDNjbC4he8rUW"
+            "cJoZmds2h7M70imEVhRU5djINXtqllXI4DFqcI1DgjT9LewND8MW2Krf3S"
+            "psk_ZkoFnilakGygTwpZ3uesH-PFABNIUYpOiN15dsQRkgr0vEhxN92i2a"
+            "sbOenSZeyaxziK72UwxrrKoExv6kc5twXTq4h-QChLOln0_mtUZwfsRaMS"
+            "tPs6mS6XrgxnxbWhojf663tuEQueGC-FCMfra36C9knDFGzKsNa7LZK2dj"
+            "YgyD3JR_MB_4NUJW_TqOQtwHYbxevoJArm-L5StowjzGy-_bq6Gw"
+        ),
+        "e": "AQAB",
+        "d": (
+            "kLdtIj6GbDks_ApCSTYQtelcNttlKiOyPzMrXHeI-yk1F7-kpDxY4-WY5N"
+            "WV5KntaEeXS1j82E375xxhWMHXyvjYecPT9fpwR_M9gV8n9Hrh2anTpTD9"
+            "3Dt62ypW3yDsJzBnTnrYu1iwWRgBKrEYY46qAZIrA2xAwnm2X7uGR1hghk"
+            "qDp0Vqj3kbSCz1XyfCs6_LehBwtxHIyh8Ripy40p24moOAbgxVw3rxT_vl"
+            "t3UVe4WO3JkJOzlpUf-KTVI2Ptgm-dARxTEtE-id-4OJr0h-K-VFs3VSnd"
+            "VTIznSxfyrj8ILL6MG_Uv8YAu7VILSB3lOW085-4qE3DzgrTjgyQ"
+        ),
+        "p": (
+            "1r52Xk46c-LsfB5P442p7atdPUrxQSy4mti_tZI3Mgf2EuFVbUoDBvaRQ-"
+            "SWxkbkmoEzL7JXroSBjSrK3YIQgYdMgyAEPTPjXv_hI2_1eTSPVZfzL0lf"
+            "fNn03IXqWF5MDFuoUYE0hzb2vhrlN_rKrbfDIwUbTrjjgieRbwC6Cl0"
+        ),
+        "q": (
+            "wLb35x7hmQWZsWJmB_vle87ihgZ19S8lBEROLIsZG4ayZVe9Hi9gDVCOBm"
+            "UDdaDYVTSNx_8Fyw1YYa9XGrGnDew00J28cRUoeBB_jKI1oma0Orv1T9aX"
+            "IWxKwd4gvxFImOWr3QRL9KEBRzk2RatUBnmDZJTIAfwTs0g68UZHvtc"
+        ),
+        "dp": (
+            "ZK-YwE7diUh0qR1tR7w8WHtolDx3MZ_OTowiFvgfeQ3SiresXjm9gZ5KL"
+            "hMXvo-uz-KUJWDxS5pFQ_M0evdo1dKiRTjVw_x4NyqyXPM5nULPkcpU827"
+            "rnpZzAJKpdhWAgqrXGKAECQH0Xt4taznjnd_zVpAmZZq60WPMBMfKcuE"
+        ),
+        "dq": (
+            "Dq0gfgJ1DdFGXiLvQEZnuKEN0UUmsJBxkjydc3j4ZYdBiMRAy86x0vHCj"
+            "ywcMlYYg4yoC4YZa9hNVcsjqA3FeiL19rk8g6Qn29Tt0cj8qqyFpz9vNDB"
+            "UfCAiJVeESOjJDZPYHdHY8v1b-o-Z2X5tvLx-TCekf7oxyeKDUqKWjis"
+        ),
+        "qi": (
+            "VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7"
+            "AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3"
+            "eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
+        ),
+    })
     iv = bytes.fromhex("e3c575fc02dbe944b4e14ddb")
 
     jwe = JweCompact.encrypt(plaintext, jwk.public_jwk(), alg=alg, enc=enc, cek=cek, iv=iv)
@@ -100,53 +98,51 @@ def test_jwe_decrypt() -> None:
         "XFBoMYUZodetZdvTiFvSkQ"
     )
 
-    jwk = Jwk(
-        {
-            "kty": "RSA",
-            "n": (
-                "oahUIoWw0K0usKNuOR6H4wkf4oBUXHTxRvgb48E-BVvxkeDNjbC4he8rUW"
-                "cJoZmds2h7M70imEVhRU5djINXtqllXI4DFqcI1DgjT9LewND8MW2Krf3S"
-                "psk_ZkoFnilakGygTwpZ3uesH-PFABNIUYpOiN15dsQRkgr0vEhxN92i2a"
-                "sbOenSZeyaxziK72UwxrrKoExv6kc5twXTq4h-QChLOln0_mtUZwfsRaMS"
-                "tPs6mS6XrgxnxbWhojf663tuEQueGC-FCMfra36C9knDFGzKsNa7LZK2dj"
-                "YgyD3JR_MB_4NUJW_TqOQtwHYbxevoJArm-L5StowjzGy-_bq6Gw"
-            ),
-            "e": "AQAB",
-            "d": (
-                "kLdtIj6GbDks_ApCSTYQtelcNttlKiOyPzMrXHeI-yk1F7-kpDxY4-WY5N"
-                "WV5KntaEeXS1j82E375xxhWMHXyvjYecPT9fpwR_M9gV8n9Hrh2anTpTD9"
-                "3Dt62ypW3yDsJzBnTnrYu1iwWRgBKrEYY46qAZIrA2xAwnm2X7uGR1hghk"
-                "qDp0Vqj3kbSCz1XyfCs6_LehBwtxHIyh8Ripy40p24moOAbgxVw3rxT_vl"
-                "t3UVe4WO3JkJOzlpUf-KTVI2Ptgm-dARxTEtE-id-4OJr0h-K-VFs3VSnd"
-                "VTIznSxfyrj8ILL6MG_Uv8YAu7VILSB3lOW085-4qE3DzgrTjgyQ"
-            ),
-            "p": (
-                "1r52Xk46c-LsfB5P442p7atdPUrxQSy4mti_tZI3Mgf2EuFVbUoDBvaRQ-"
-                "SWxkbkmoEzL7JXroSBjSrK3YIQgYdMgyAEPTPjXv_hI2_1eTSPVZfzL0lf"
-                "fNn03IXqWF5MDFuoUYE0hzb2vhrlN_rKrbfDIwUbTrjjgieRbwC6Cl0"
-            ),
-            "q": (
-                "wLb35x7hmQWZsWJmB_vle87ihgZ19S8lBEROLIsZG4ayZVe9Hi9gDVCOBm"
-                "UDdaDYVTSNx_8Fyw1YYa9XGrGnDew00J28cRUoeBB_jKI1oma0Orv1T9aX"
-                "IWxKwd4gvxFImOWr3QRL9KEBRzk2RatUBnmDZJTIAfwTs0g68UZHvtc"
-            ),
-            "dp": (
-                "ZK-YwE7diUh0qR1tR7w8WHtolDx3MZ_OTowiFvgfeQ3SiresXjm9gZ5KL"
-                "hMXvo-uz-KUJWDxS5pFQ_M0evdo1dKiRTjVw_x4NyqyXPM5nULPkcpU827"
-                "rnpZzAJKpdhWAgqrXGKAECQH0Xt4taznjnd_zVpAmZZq60WPMBMfKcuE"
-            ),
-            "dq": (
-                "Dq0gfgJ1DdFGXiLvQEZnuKEN0UUmsJBxkjydc3j4ZYdBiMRAy86x0vHCj"
-                "ywcMlYYg4yoC4YZa9hNVcsjqA3FeiL19rk8g6Qn29Tt0cj8qqyFpz9vNDB"
-                "UfCAiJVeESOjJDZPYHdHY8v1b-o-Z2X5tvLx-TCekf7oxyeKDUqKWjis"
-            ),
-            "qi": (
-                "VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7"
-                "AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3"
-                "eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
-            ),
-        }
-    )
+    jwk = Jwk({
+        "kty": "RSA",
+        "n": (
+            "oahUIoWw0K0usKNuOR6H4wkf4oBUXHTxRvgb48E-BVvxkeDNjbC4he8rUW"
+            "cJoZmds2h7M70imEVhRU5djINXtqllXI4DFqcI1DgjT9LewND8MW2Krf3S"
+            "psk_ZkoFnilakGygTwpZ3uesH-PFABNIUYpOiN15dsQRkgr0vEhxN92i2a"
+            "sbOenSZeyaxziK72UwxrrKoExv6kc5twXTq4h-QChLOln0_mtUZwfsRaMS"
+            "tPs6mS6XrgxnxbWhojf663tuEQueGC-FCMfra36C9knDFGzKsNa7LZK2dj"
+            "YgyD3JR_MB_4NUJW_TqOQtwHYbxevoJArm-L5StowjzGy-_bq6Gw"
+        ),
+        "e": "AQAB",
+        "d": (
+            "kLdtIj6GbDks_ApCSTYQtelcNttlKiOyPzMrXHeI-yk1F7-kpDxY4-WY5N"
+            "WV5KntaEeXS1j82E375xxhWMHXyvjYecPT9fpwR_M9gV8n9Hrh2anTpTD9"
+            "3Dt62ypW3yDsJzBnTnrYu1iwWRgBKrEYY46qAZIrA2xAwnm2X7uGR1hghk"
+            "qDp0Vqj3kbSCz1XyfCs6_LehBwtxHIyh8Ripy40p24moOAbgxVw3rxT_vl"
+            "t3UVe4WO3JkJOzlpUf-KTVI2Ptgm-dARxTEtE-id-4OJr0h-K-VFs3VSnd"
+            "VTIznSxfyrj8ILL6MG_Uv8YAu7VILSB3lOW085-4qE3DzgrTjgyQ"
+        ),
+        "p": (
+            "1r52Xk46c-LsfB5P442p7atdPUrxQSy4mti_tZI3Mgf2EuFVbUoDBvaRQ-"
+            "SWxkbkmoEzL7JXroSBjSrK3YIQgYdMgyAEPTPjXv_hI2_1eTSPVZfzL0lf"
+            "fNn03IXqWF5MDFuoUYE0hzb2vhrlN_rKrbfDIwUbTrjjgieRbwC6Cl0"
+        ),
+        "q": (
+            "wLb35x7hmQWZsWJmB_vle87ihgZ19S8lBEROLIsZG4ayZVe9Hi9gDVCOBm"
+            "UDdaDYVTSNx_8Fyw1YYa9XGrGnDew00J28cRUoeBB_jKI1oma0Orv1T9aX"
+            "IWxKwd4gvxFImOWr3QRL9KEBRzk2RatUBnmDZJTIAfwTs0g68UZHvtc"
+        ),
+        "dp": (
+            "ZK-YwE7diUh0qR1tR7w8WHtolDx3MZ_OTowiFvgfeQ3SiresXjm9gZ5KL"
+            "hMXvo-uz-KUJWDxS5pFQ_M0evdo1dKiRTjVw_x4NyqyXPM5nULPkcpU827"
+            "rnpZzAJKpdhWAgqrXGKAECQH0Xt4taznjnd_zVpAmZZq60WPMBMfKcuE"
+        ),
+        "dq": (
+            "Dq0gfgJ1DdFGXiLvQEZnuKEN0UUmsJBxkjydc3j4ZYdBiMRAy86x0vHCj"
+            "ywcMlYYg4yoC4YZa9hNVcsjqA3FeiL19rk8g6Qn29Tt0cj8qqyFpz9vNDB"
+            "UfCAiJVeESOjJDZPYHdHY8v1b-o-Z2X5tvLx-TCekf7oxyeKDUqKWjis"
+        ),
+        "qi": (
+            "VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7"
+            "AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3"
+            "eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
+        ),
+    })
 
     plaintext = b"The true sign of intelligence is not knowledge but imagination."
     alg = "RSA-OAEP"

--- a/tests/test_jwe.py
+++ b/tests/test_jwe.py
@@ -632,9 +632,9 @@ def test_decrypt_by_jwcrypto(
         encryption_alg: the encryption alg
 
     """
-    import jwcrypto.jwe  # type: ignore[import]
-    import jwcrypto.jwk  # type: ignore[import]
-    from jwcrypto.common import InvalidJWEOperation, json_encode  # type: ignore[import]
+    import jwcrypto.jwe  # type: ignore[import-untyped]
+    import jwcrypto.jwk  # type: ignore[import-untyped]
+    from jwcrypto.common import InvalidJWEOperation, json_encode  # type: ignore[import-untyped]
 
     if key_management_alg in JWCRYPTO_UNSUPPORTED_ALGS:
         pytest.skip(f"jwcrypto doesn't support key management alg {key_management_alg}")

--- a/tests/test_jwk/test_ec.py
+++ b/tests/test_jwk/test_ec.py
@@ -113,15 +113,13 @@ def test_pem_key(crv: str) -> None:
 
 
 def test_public_private() -> None:
-    jwk = Jwk(
-        {
-            "kty": "EC",
-            "crv": "P-256",
-            "x": "WtjnvHG9b_IKBLn4QYTHz-AdoAiO_ork5LH1BL_5tyI",
-            "y": "C0YfOUDuCOvTCt7hAqO-f9z8_JdOnOPbfYmUk-RosHA",
-            "d": "EnGZlkoa4VUsnl72LcRRychNJ2FFknm_ph855tNuPZ8",
-        }
-    )
+    jwk = Jwk({
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "WtjnvHG9b_IKBLn4QYTHz-AdoAiO_ork5LH1BL_5tyI",
+        "y": "C0YfOUDuCOvTCt7hAqO-f9z8_JdOnOPbfYmUk-RosHA",
+        "d": "EnGZlkoa4VUsnl72LcRRychNJ2FFknm_ph855tNuPZ8",
+    })
 
     assert (
         ECJwk.public(

--- a/tests/test_jwk/test_jwk.py
+++ b/tests/test_jwk/test_jwk.py
@@ -61,14 +61,12 @@ def test_invalid_jwk() -> None:
 
     with pytest.raises(InvalidJwk):
         # attribute 'd' (private exponent) is missing
-        Jwk(
-            {
-                "kty": "RSA",
-                "n": "oRHn4oGv23ylRL3RSsL4p_e6Ywinnj2N2tT5OLe5pEZTg-LFBhjFxcJaB-p1dh6XX47EtSfa-JHffU0o5ZRK2ySyNDtlrFAkOpAHH6U83ayE2QPYGzrFrrvHDa8wIMUWymzxpPwGgKBwZZqtTT6d-iy4Ux3AWV-bUv6Z7WijHnOy7aVzZ4dFERLVf2FaaYXDET7GO4v-oQ5ss_guYdmewN039jxkjz_KrA-0Fyhalf9hL8IHfpdpSlHosrmjORG5y9LkYK0J6zxSBF5ZvLIBK33BTzPPiCMwKLyAcV6qdcAcvV4kthKO0iUKBK4eE8D0N8HcSPvA9F_PpLS_k5F2lw",
-                "e": "AQAB",
-                "p": "0mzP9sbFxU5YxNNLgUEdRQSO-ojqWrzbI02PfQLGyzXumvOh_Qr73OpHStU8CAAcUBaQdRGidsVdb5cq6JG2zvbEEYiX-dCHqTJs8wfktGCL7eV-ZVh7fhJ1sYVBN20yv8aSH63uUPZnJXR1AUyrvRumuerdPxp8X951PESrJd0",
-            }
-        )
+        Jwk({
+            "kty": "RSA",
+            "n": "oRHn4oGv23ylRL3RSsL4p_e6Ywinnj2N2tT5OLe5pEZTg-LFBhjFxcJaB-p1dh6XX47EtSfa-JHffU0o5ZRK2ySyNDtlrFAkOpAHH6U83ayE2QPYGzrFrrvHDa8wIMUWymzxpPwGgKBwZZqtTT6d-iy4Ux3AWV-bUv6Z7WijHnOy7aVzZ4dFERLVf2FaaYXDET7GO4v-oQ5ss_guYdmewN039jxkjz_KrA-0Fyhalf9hL8IHfpdpSlHosrmjORG5y9LkYK0J6zxSBF5ZvLIBK33BTzPPiCMwKLyAcV6qdcAcvV4kthKO0iUKBK4eE8D0N8HcSPvA9F_PpLS_k5F2lw",
+            "e": "AQAB",
+            "p": "0mzP9sbFxU5YxNNLgUEdRQSO-ojqWrzbI02PfQLGyzXumvOh_Qr73OpHStU8CAAcUBaQdRGidsVdb5cq6JG2zvbEEYiX-dCHqTJs8wfktGCL7eV-ZVh7fhJ1sYVBN20yv8aSH63uUPZnJXR1AUyrvRumuerdPxp8X951PESrJd0",
+        })
 
     with pytest.raises(InvalidJwk):
         # k is not a str
@@ -84,15 +82,13 @@ def test_invalid_jwk() -> None:
 
     with pytest.raises(InvalidJwk):
         # key is public and has key_ops: ["sign"]
-        Jwk(
-            {
-                "kty": "EC",
-                "key_ops": ["sign"],
-                "crv": "P-256",
-                "x": "vGVh-60pT34a0JLeiaers66I0JLRilpf5tbnZsa-q3U",
-                "y": "y99gwPgQH1lrIBQPwgJoHCoeQjF96M7XfxGXu_Pjyzk",
-            }
-        )
+        Jwk({
+            "kty": "EC",
+            "key_ops": ["sign"],
+            "crv": "P-256",
+            "x": "vGVh-60pT34a0JLeiaers66I0JLRilpf5tbnZsa-q3U",
+            "y": "y99gwPgQH1lrIBQPwgJoHCoeQjF96M7XfxGXu_Pjyzk",
+        })
 
     with pytest.raises(TypeError):
         Jwk.from_cryptography_key(object())
@@ -185,16 +181,14 @@ def test_invalid_params() -> None:
         Jwk({"kty": "oct", "k": "foobar", "kid": 1.34}).kid
 
     with pytest.raises(InvalidJwk):
-        Jwk(
-            {
-                "kty": "EC",
-                "crv": "P-256",
-                "x": "SOlwe9_nRwz2f9Y2aSB9d7D-AXTSSBlAQd5HZUIEGLA",
-                "y": "Pzk9Gd4wwbx9STkK_RfWqxnfU9AwpvWZzf_K0GpaQZo",
-                "d": "Invalid-private-key--EHzgbRaNKRCMhk6jiCT-ZQ",
-                "alg": "ES256",
-            }
-        )
+        Jwk({
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "SOlwe9_nRwz2f9Y2aSB9d7D-AXTSSBlAQd5HZUIEGLA",
+            "y": "Pzk9Gd4wwbx9STkK_RfWqxnfU9AwpvWZzf_K0GpaQZo",
+            "d": "Invalid-private-key--EHzgbRaNKRCMhk6jiCT-ZQ",
+            "alg": "ES256",
+        })
 
 
 def test_invalid_class_for_kty() -> None:
@@ -246,22 +240,20 @@ def test_use_key_ops_with_alg(alg: str, use: str, private_key_ops: tuple[str], p
 
 def test_thumbprint() -> None:
     # key from https://www.rfc-editor.org/rfc/rfc7638.html#section-3.1
-    jwk = Jwk(
-        {
-            "kty": "RSA",
-            "n": (
-                "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAt"
-                "VT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn6"
-                "4tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FD"
-                "W2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n9"
-                "1CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINH"
-                "aQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
-            ),
-            "e": "AQAB",
-            "alg": "RS256",
-            "kid": "2011-04-29",
-        }
-    )
+    jwk = Jwk({
+        "kty": "RSA",
+        "n": (
+            "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAt"
+            "VT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn6"
+            "4tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FD"
+            "W2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n9"
+            "1CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINH"
+            "aQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+        ),
+        "e": "AQAB",
+        "alg": "RS256",
+        "kid": "2011-04-29",
+    })
 
     assert jwk.thumbprint() == "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
     assert (

--- a/tests/test_jwk/test_jwks.py
+++ b/tests/test_jwk/test_jwks.py
@@ -90,49 +90,47 @@ def test_empty_jwkset() -> None:
 
 
 def test_public_jwkset() -> None:
-    jwks = JwkSet(
-        {
-            "keys": [
-                {
-                    "kty": "RSA",
-                    "alg": "RS256",
-                    "n": "iA7fKKnBz724Yqhe6ejEckSpqPCW0O1_3hUcW9GFC8OVgwWIG6Z6gwjLJFJPHQ7D-JT_Bc7UJ_3iBpUmEO_600SQu9jg8fVcf-OlDRvnMRuXMKYyyjWn50mfMZH9eHTBuw4h96rdIVm9N8ml0VsouJc59O7PjLi93HvzpV1PQM0m6it7oHfVPX_Gdm6cg6qWcc6yQ1jdW-YzkOp_nRCy81cVAvp_tKapaiXGIrpWipgBDObXSDeQ5qbArvL0P8N176g4Hia1WtpJoe7H1b_Km2e-gkl8UZVGN5-vSKryh1CKifD6uwLEvoHlHUvWdIqsSx7dPLchz07S81Qp2YpexulnfdA2VoZsH9AKrRtkf1_a3OSx0wFDxfOoRyTQblC1MZ8Dvf6PQ_stsc0-zBOjHa4jdunjneMUOuJmw3jaUl7MFAjcBS951mSqWoNUSOL8QgDEj3-jDghFGZmHZkjXfoflAmjbCUH6mRSTKgu9LzeKEWeKc9lSjwDRo9BNzq0X2qEzEqVexd96wJ7FkZ_zjyDWJlIElMy81fDcaX2Lh0AS0VOPDlAm6D5Py931V6jylI-Uz-3rQHuWiWUjZWp9ZB1OlYDC-nNFdJPqPxDQIgrODAvYMphK_R1NObdXjbwhr8qxZNRNXmqGB4FH-v6CGeNLOTB5FgmfndzX3utjk40",
-                    "e": "AQAB",
-                    "kid": "7KJgpwNvHJp_zb6SybahlC7506kvAm2cvMG_EY6jmx8",
-                },
-                {
-                    "kty": "EC",
-                    "alg": "ES256",
-                    "crv": "P-256",
-                    "x": "Y3oM13zJ47UkSxuYRFP86cknI-JjMc9Nz39SA6R5EjQ",
-                    "y": "pvA66-cfoNxK4TMTo3Wq-o7npJe5yRow9FPdP8N1s5Y",
-                    "kid": "ojHE_6b7DXtOwLKYTmeao38CV_7P9F9rYTLGm8BuJnk",
-                },
-                {
-                    "kty": "RSA",
-                    "alg": "PS256",
-                    "n": "rhvS1HWLDPKP2_I4a1_RhLwnRjVDT_0tGDScPO67fBH7ImzkK_BrDnBzY2Fsz9VozWrCh0G_SnAKimmIGcfLI-AL2lFX2413y28jfHf5uGGKSXnaYu1lUtX51MlvbbQnhEtsVkJUcBEFZgzl4EztZ1YeXGuY0gbeqBUOmudWA5yBHvB_wkMg4vNX4H6Aa7jRdfVA1xUM43BHl6zIXpjsxAlfmjCd7Ifh9gOxj5skDd1rYLBcQsaF2Qmh_KWYrWagQH_WN0JDF9vSBRK5nNSfyHSAv72WhL4p_2Jz1fkYUsIOcoaoP3JTjZYYH4ht2QpqjfYXB50rJlUwX-DQ7-SyclXJwf571gspv9aJ4ahnux1g-26ByXyasBGzrJfhbOUGN2QC7O1OWk903vV6VtqYZjxLuW5pi7GFTB1psROtgBCdX-2sXjAr_Up4DFwNWc4AwQqfuuXAIjc9NS7x66ar1Dsj32YsiowfwB-raLZYm4H8A1AuN7zOX6A0JosVENuJT9e7Fl3wermpIWx4QRN76WOLYba_8uyTP0-R2kmgoxI2Xzt1RqtRXnwqD6_dqnMRdyx2zSnBFU3y5ICtWqOCjM9bm2Orym3ZfPpBbpZkkMLXYik7oae0kpA6yJf3FMQSTY_-66sPWgeT9jgpwC_qFxDrBEy9hOCO5VJ6NUkmdnk",
-                    "e": "AQAB",
-                    "kid": "m7XoZRBgXXjEFxGhWvb_urskl4rCLmOhhPRdC6278-E",
-                },
-                {
-                    "kty": "EC",
-                    "alg": "ECDH-ES",
-                    "crv": "P-256",
-                    "x": "m98Qjjc1OlN1dVD0q7yetQfOVl0iHtcqHZpJ0ZeOkZQ",
-                    "y": "g3PoI3YykxNj4H4Ffc8NF8Sf4MYXIkZzMN2wFBfD0fc",
-                    "kid": "xAgzqjWdBD8cRifXbpmcv-9vIgjKHTdjelI-Vvu0K9Q",
-                },
-                {
-                    "kty": "RSA",
-                    "alg": "RSA-OAEP-256",
-                    "n": "tGeChePEEOjo3j9SL15OjqL67w_SBaN4H5LxhXFMEcnIoAVpuGGwu18NuN2oRPabsuvJ3yDg0v4WZck5keftfs5cgal8P9J_MB8greSErmLRTDRmSqFlysEJaGuFABbbUXZZk1bO_Ea-dSKJgeNUEpJf4n_JiTtxEFgB8fTeh1RWsESOqB7tYaQNaSy4Ckt_0TF3000BL92SsvepFIyTKoL77ZnRxbAd0WQ-H7flIKbuyex_5JuTZ4amI2xJE-TThEU_KN-yVbLDWaIhUAEE-51bC2DtceyuWSBO4QmToLG9oefaF49VdxaKMWeUnrfJ9pfM2AM12S8G6k_fQPpyFflXrBlRvWEC769RECucBRDzkgBnLGQPeUKwsKfvjiQC-Eat_WFE5t3D7OiZISDEBjrW728PGMEKcHzQq1ut5Eu7BOpC95emJgattURmGSSI5988_6vebsD37iRdBlqQrcYAq7SUI9-aaPL0CEDCWZ_vC0Rnxx0BRHM32JwVb-Ac0gJcTo6WaL1NKzp1CdixXBXdVBFEyB1pGDfi9-bAcM1YMTLylmmkxUagSHVvQnPqbO2djwI2koFH305Oa5ABAlgenpNb8BSGnRC0h5yzaKn0D8e_JgNv--JIhGTOeMmIG69CMQwONdzEuhCy4wGBChhjEQaiI_pTKhah0U5hIHM",
-                    "e": "AQAB",
-                    "kid": "zjY2pjFnBc4rOHWEwfS5Cjyxsjo2aprsctM-4oS1r8I",
-                },
-            ]
-        }
-    )
+    jwks = JwkSet({
+        "keys": [
+            {
+                "kty": "RSA",
+                "alg": "RS256",
+                "n": "iA7fKKnBz724Yqhe6ejEckSpqPCW0O1_3hUcW9GFC8OVgwWIG6Z6gwjLJFJPHQ7D-JT_Bc7UJ_3iBpUmEO_600SQu9jg8fVcf-OlDRvnMRuXMKYyyjWn50mfMZH9eHTBuw4h96rdIVm9N8ml0VsouJc59O7PjLi93HvzpV1PQM0m6it7oHfVPX_Gdm6cg6qWcc6yQ1jdW-YzkOp_nRCy81cVAvp_tKapaiXGIrpWipgBDObXSDeQ5qbArvL0P8N176g4Hia1WtpJoe7H1b_Km2e-gkl8UZVGN5-vSKryh1CKifD6uwLEvoHlHUvWdIqsSx7dPLchz07S81Qp2YpexulnfdA2VoZsH9AKrRtkf1_a3OSx0wFDxfOoRyTQblC1MZ8Dvf6PQ_stsc0-zBOjHa4jdunjneMUOuJmw3jaUl7MFAjcBS951mSqWoNUSOL8QgDEj3-jDghFGZmHZkjXfoflAmjbCUH6mRSTKgu9LzeKEWeKc9lSjwDRo9BNzq0X2qEzEqVexd96wJ7FkZ_zjyDWJlIElMy81fDcaX2Lh0AS0VOPDlAm6D5Py931V6jylI-Uz-3rQHuWiWUjZWp9ZB1OlYDC-nNFdJPqPxDQIgrODAvYMphK_R1NObdXjbwhr8qxZNRNXmqGB4FH-v6CGeNLOTB5FgmfndzX3utjk40",
+                "e": "AQAB",
+                "kid": "7KJgpwNvHJp_zb6SybahlC7506kvAm2cvMG_EY6jmx8",
+            },
+            {
+                "kty": "EC",
+                "alg": "ES256",
+                "crv": "P-256",
+                "x": "Y3oM13zJ47UkSxuYRFP86cknI-JjMc9Nz39SA6R5EjQ",
+                "y": "pvA66-cfoNxK4TMTo3Wq-o7npJe5yRow9FPdP8N1s5Y",
+                "kid": "ojHE_6b7DXtOwLKYTmeao38CV_7P9F9rYTLGm8BuJnk",
+            },
+            {
+                "kty": "RSA",
+                "alg": "PS256",
+                "n": "rhvS1HWLDPKP2_I4a1_RhLwnRjVDT_0tGDScPO67fBH7ImzkK_BrDnBzY2Fsz9VozWrCh0G_SnAKimmIGcfLI-AL2lFX2413y28jfHf5uGGKSXnaYu1lUtX51MlvbbQnhEtsVkJUcBEFZgzl4EztZ1YeXGuY0gbeqBUOmudWA5yBHvB_wkMg4vNX4H6Aa7jRdfVA1xUM43BHl6zIXpjsxAlfmjCd7Ifh9gOxj5skDd1rYLBcQsaF2Qmh_KWYrWagQH_WN0JDF9vSBRK5nNSfyHSAv72WhL4p_2Jz1fkYUsIOcoaoP3JTjZYYH4ht2QpqjfYXB50rJlUwX-DQ7-SyclXJwf571gspv9aJ4ahnux1g-26ByXyasBGzrJfhbOUGN2QC7O1OWk903vV6VtqYZjxLuW5pi7GFTB1psROtgBCdX-2sXjAr_Up4DFwNWc4AwQqfuuXAIjc9NS7x66ar1Dsj32YsiowfwB-raLZYm4H8A1AuN7zOX6A0JosVENuJT9e7Fl3wermpIWx4QRN76WOLYba_8uyTP0-R2kmgoxI2Xzt1RqtRXnwqD6_dqnMRdyx2zSnBFU3y5ICtWqOCjM9bm2Orym3ZfPpBbpZkkMLXYik7oae0kpA6yJf3FMQSTY_-66sPWgeT9jgpwC_qFxDrBEy9hOCO5VJ6NUkmdnk",
+                "e": "AQAB",
+                "kid": "m7XoZRBgXXjEFxGhWvb_urskl4rCLmOhhPRdC6278-E",
+            },
+            {
+                "kty": "EC",
+                "alg": "ECDH-ES",
+                "crv": "P-256",
+                "x": "m98Qjjc1OlN1dVD0q7yetQfOVl0iHtcqHZpJ0ZeOkZQ",
+                "y": "g3PoI3YykxNj4H4Ffc8NF8Sf4MYXIkZzMN2wFBfD0fc",
+                "kid": "xAgzqjWdBD8cRifXbpmcv-9vIgjKHTdjelI-Vvu0K9Q",
+            },
+            {
+                "kty": "RSA",
+                "alg": "RSA-OAEP-256",
+                "n": "tGeChePEEOjo3j9SL15OjqL67w_SBaN4H5LxhXFMEcnIoAVpuGGwu18NuN2oRPabsuvJ3yDg0v4WZck5keftfs5cgal8P9J_MB8greSErmLRTDRmSqFlysEJaGuFABbbUXZZk1bO_Ea-dSKJgeNUEpJf4n_JiTtxEFgB8fTeh1RWsESOqB7tYaQNaSy4Ckt_0TF3000BL92SsvepFIyTKoL77ZnRxbAd0WQ-H7flIKbuyex_5JuTZ4amI2xJE-TThEU_KN-yVbLDWaIhUAEE-51bC2DtceyuWSBO4QmToLG9oefaF49VdxaKMWeUnrfJ9pfM2AM12S8G6k_fQPpyFflXrBlRvWEC769RECucBRDzkgBnLGQPeUKwsKfvjiQC-Eat_WFE5t3D7OiZISDEBjrW728PGMEKcHzQq1ut5Eu7BOpC95emJgattURmGSSI5988_6vebsD37iRdBlqQrcYAq7SUI9-aaPL0CEDCWZ_vC0Rnxx0BRHM32JwVb-Ac0gJcTo6WaL1NKzp1CdixXBXdVBFEyB1pGDfi9-bAcM1YMTLylmmkxUagSHVvQnPqbO2djwI2koFH305Oa5ABAlgenpNb8BSGnRC0h5yzaKn0D8e_JgNv--JIhGTOeMmIG69CMQwONdzEuhCy4wGBChhjEQaiI_pTKhah0U5hIHM",
+                "e": "AQAB",
+                "kid": "zjY2pjFnBc4rOHWEwfS5Cjyxsjo2aprsctM-4oS1r8I",
+            },
+        ]
+    })
     assert not jwks.is_private
     sig_keys = jwks.verification_keys()
     enc_keys = jwks.encryption_keys()

--- a/tests/test_jwk/test_okp.py
+++ b/tests/test_jwk/test_okp.py
@@ -47,14 +47,12 @@ def test_generate_unsupported() -> None:
 
 def test_rfc8037_ed25519() -> None:
     """Test from [RFC8037][https://www.rfc-editor.org/rfc/rfc8037.html#appendix-A]."""
-    jwk = Jwk(
-        {
-            "kty": "OKP",
-            "crv": "Ed25519",
-            "d": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
-            "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
-        }
-    )
+    jwk = Jwk({
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "d": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
+        "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+    })
     assert isinstance(jwk, OKPJwk)
     assert jwk.is_private
     assert jwk.private_key == bytes.fromhex("""
@@ -87,14 +85,12 @@ def test_rfc8037_ed25519() -> None:
 
 def test_rfc8037_x25519() -> None:
     """Test from [RFC8037 $A.6][https://www.rfc-editor.org/rfc/rfc8037.html#appendix-A.6]."""
-    public_jwk = Jwk(
-        {
-            "kty": "OKP",
-            "crv": "X25519",
-            "kid": "Bob",
-            "x": "3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08",
-        }
-    )
+    public_jwk = Jwk({
+        "kty": "OKP",
+        "crv": "X25519",
+        "kid": "Bob",
+        "x": "3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08",
+    })
     assert isinstance(public_jwk, OKPJwk)
     assert public_jwk.public_key == bytes.fromhex("""de 9e db 7d 7b 7d c1 b4 d3 5b 61 c2 ec e4 35 37
    3f 83 43 c8 5b 78 67 4d ad fc 7e 14 6f 88 2b 4f""")
@@ -104,13 +100,11 @@ def test_rfc8037_x25519() -> None:
 
     ephemeral_private_key = OKPJwk.from_bytes(ephemeral_secret, use="enc")
 
-    assert ephemeral_private_key.public_jwk() == Jwk(
-        {
-            "kty": "OKP",
-            "crv": "X25519",
-            "x": "hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr066SpjqqbTmo",
-        }
-    )
+    assert ephemeral_private_key.public_jwk() == Jwk({
+        "kty": "OKP",
+        "crv": "X25519",
+        "x": "hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr066SpjqqbTmo",
+    })
 
     ephemeral_private_key["kid"] = "Bob"
 
@@ -124,14 +118,12 @@ def test_rfc8037_x25519() -> None:
 
 def test_rfc8037_x448() -> None:
     """Test from [RFC8037 $A.7][https://www.rfc-editor.org/rfc/rfc8037.html#appendix-A.7]."""
-    public_jwk = Jwk(
-        {
-            "kty": "OKP",
-            "crv": "X448",
-            "kid": "Dave",
-            "x": "PreoKbDNIPW8_AtZm2_sz22kYnEHvbDU80W0MCfYuXL8PjT7QjKhPKcG3LV67D2uB73BxnvzNgk",
-        }
-    )
+    public_jwk = Jwk({
+        "kty": "OKP",
+        "crv": "X448",
+        "kid": "Dave",
+        "x": "PreoKbDNIPW8_AtZm2_sz22kYnEHvbDU80W0MCfYuXL8PjT7QjKhPKcG3LV67D2uB73BxnvzNgk",
+    })
     assert isinstance(public_jwk, OKPJwk)
     assert public_jwk.public_key == bytes.fromhex("""
    3e b7 a8 29 b0 cd 20 f5 bc fc 0b 59 9b 6f ec cf
@@ -147,13 +139,11 @@ def test_rfc8037_x448() -> None:
 
     ephemeral_private_key = OKPJwk.from_bytes(ephemeral_secret, use="enc")
 
-    assert ephemeral_private_key.public_jwk() == Jwk(
-        {
-            "kty": "OKP",
-            "crv": "X448",
-            "x": "mwj3zDG34-Z9ItWuoSEHSic70rg94Jxj-qc9LCLF2bvINmRyQdlT1AxbEtqIEg1TF3-A5TLEH6A",
-        }
-    )
+    assert ephemeral_private_key.public_jwk() == Jwk({
+        "kty": "OKP",
+        "crv": "X448",
+        "x": "mwj3zDG34-Z9ItWuoSEHSic70rg94Jxj-qc9LCLF2bvINmRyQdlT1AxbEtqIEg1TF3-A5TLEH6A",
+    })
 
     ephemeral_private_key["kid"] = "Bob"
 
@@ -302,14 +292,12 @@ def test_from_bytes(private_key: bytes, crv: str, use: str) -> None:
 
 
 def test_public_private() -> None:
-    jwk = Jwk(
-        {
-            "kty": "OKP",
-            "crv": "Ed25519",
-            "x": "SghwA3Kg8e1Z2v1xnfnexH7OE4G-cd1z__Q64RQR4EQ",
-            "d": "V7P8eIm8sZsvIlhOXMLiamWTUW68wpyFyW_1QrnzkAI",
-        }
-    )
+    jwk = Jwk({
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "SghwA3Kg8e1Z2v1xnfnexH7OE4G-cd1z__Q64RQR4EQ",
+        "d": "V7P8eIm8sZsvIlhOXMLiamWTUW68wpyFyW_1QrnzkAI",
+    })
 
     assert (
         OKPJwk.public(

--- a/tests/test_jwk/test_rsa.py
+++ b/tests/test_jwk/test_rsa.py
@@ -154,14 +154,12 @@ def test_pem_key(key_size: int) -> None:
 
 
 def test_optional_parameters() -> None:
-    jwk = RSAJwk(
-        {
-            "kty": "RSA",
-            "n": "vrTLXnpOv8Fe5stFYhmYrFKYUBcHpZU6GdtbXYRNPjBTAl2FMWE_chq5OMaM2QHBaAVLy62_xDV4AoUHydAlUoPtCtrxb9ViQnBpDytfXuhVEvAl0-K3zkWNVlOuLxDjp85cImbcPzmwrFADqAREPkCQh31V7tnlttlXlEYqDC_Cra8OnnPFwxRqcpcIWQmj2zy95TdJ1TQLv2HOYAbb1Ql1HhPhYJBFHcX4fhTVM0g-7JKOWRN7CBVudW3s5jqxgzykfkTopLDS0frP2ivz8p1vgHrXQKJr0M-dnj7FZzYiam8zBoTzOFRQ3-_QgWdu9Z9BCvJfpXhepZWu4Ryjiw",
-            "e": "AQAB",
-            "d": "AxJHWjivDwCOxjnM3sUZw-C6qkOMsHqESolRYeKxGcjOdXHLJN3zlyNeC0-LUi1oj4PSUi_0sDTKP4Qj-XicOUV9qliXXd06bWaBEqj4qr8kK59phI2Ytz5AhfzoB8MGX5v_uOAeOPh1Y3kQbgLPlI8WpM_8c9HXlMfQVMeCgtq08Vv15-eC6xeLqkNajQ8eEz3ZTt8eVuY5ElwiVAx8dl833_AV5E7s27mCoFWsd73zMk3ej1-eq0y4lwL7nHPPrM6JEdCrhMQgyR8BKmFZT14Ozm7W7p0W6llKY6SWV8VUEpnDbZrbm2Bpq_fvEptICE-byzIMVEN53KF9Mwo09Q",
-        }
-    )
+    jwk = RSAJwk({
+        "kty": "RSA",
+        "n": "vrTLXnpOv8Fe5stFYhmYrFKYUBcHpZU6GdtbXYRNPjBTAl2FMWE_chq5OMaM2QHBaAVLy62_xDV4AoUHydAlUoPtCtrxb9ViQnBpDytfXuhVEvAl0-K3zkWNVlOuLxDjp85cImbcPzmwrFADqAREPkCQh31V7tnlttlXlEYqDC_Cra8OnnPFwxRqcpcIWQmj2zy95TdJ1TQLv2HOYAbb1Ql1HhPhYJBFHcX4fhTVM0g-7JKOWRN7CBVudW3s5jqxgzykfkTopLDS0frP2ivz8p1vgHrXQKJr0M-dnj7FZzYiam8zBoTzOFRQ3-_QgWdu9Z9BCvJfpXhepZWu4Ryjiw",
+        "e": "AQAB",
+        "d": "AxJHWjivDwCOxjnM3sUZw-C6qkOMsHqESolRYeKxGcjOdXHLJN3zlyNeC0-LUi1oj4PSUi_0sDTKP4Qj-XicOUV9qliXXd06bWaBEqj4qr8kK59phI2Ytz5AhfzoB8MGX5v_uOAeOPh1Y3kQbgLPlI8WpM_8c9HXlMfQVMeCgtq08Vv15-eC6xeLqkNajQ8eEz3ZTt8eVuY5ElwiVAx8dl833_AV5E7s27mCoFWsd73zMk3ej1-eq0y4lwL7nHPPrM6JEdCrhMQgyR8BKmFZT14Ozm7W7p0W6llKY6SWV8VUEpnDbZrbm2Bpq_fvEptICE-byzIMVEN53KF9Mwo09Q",
+    })
     assert "qi" not in jwk
     assert "p" not in jwk
     assert "q" not in jwk
@@ -253,14 +251,12 @@ def test_from_cryptography_key() -> None:
 
 
 def test_public_private() -> None:
-    jwk = Jwk(
-        {
-            "kty": "RSA",
-            "n": "jp5HPGxg9n6u0HhJaNuE_hzQIPJ_AUfalQ5rw3gZpRNTCNSIQ2aNyIwzyt58zt-YUttb5OirSkhwuiTBm--U4jHJdg57Yy4m_r06ps-3w08HI8XWh6MSAeQwiovtGLSvQ76WGdkwTSeVcST_G9qy3osJdc9xTNwyrPyyfxDef6h8s6_v2GS-xXrKzYy78eoGMezw4-uetIWV5aVfuQ3QpkVo8hN2G0YKEAwRR_zbrzY7HUiCdvbdX-RglT94MOU-_QjUcP1rBYn1z8nOZ0uA_E9UbEnIMTR0IptepaD5NpqDnYFqm_FfOhDw5-hwMxuHw-rHYnvYY78bE4g3RrV8HGMe2CltveUy6VxR4PIJ0-OY7La9ycsSWMDUN5tuluyyM5PdLvwq1aQEzNFhnR0QXe4XRVrFEoSeyAZ7Wd4I4UYKzkPzXDifgPCwFIJNYtQ69q_dSAmCVq_hxwfAV4WkjX4mjb42YmEgKr8Siz3IQ2ZRN78KNClgdSVpJYAnmk37Y9kxhvQMerwiBWKFK8y9OZsoW0jukKJx6jOH2o8nUj630AU5QhjvHfrwS_SAp_leJTpP0o1IW0Hja_AvnaDJNhkn-Jt_zOtH4K2bc1ADbce3kWAxe9Q6XtBRPPYK8BVqUuIaWPHJ6ciHWnE1lvF8dO5oALpnmstb0LfiFimm9yk",
-            "e": "AQAB",
-            "d": "FRFeGhezgi5IIj0msQH-pTA58agI6XZFHLBO7Ib1GNzgLwWAZJ6Fctr9Oqp_uuquXI0Rh-D0DsrhNipAXIn5jymGJnWwtf_HHGn1PFeigIxP1HHBBXPqMNPV9N2DRptIacRBdauPFlKy4Y4yzllSA4x79waQKOe9Z68DqkAici7ATyX-ExQc11zSkSdJS00EIcNr-Wtg3C-Aq3YwzAw1pp5JyLrlv1UrHuA9fEom5Lzo4iRIO40vuh7pQprn5Sc0VRpFEbTp5p1Q7eNUpY8yjHMmmEGU_GnQfx0_D84WCoIsT6vixQsUw2XlxIhibLZUKbWowwxi9KcyN4Ivkjc0kF-DCkB-27abRlDzWRDbImipZ_GzVl54A4nyQ_oiY4iY3Yg7Fn49bUHfi2kn2WkoJbXe0L_Ju-7OKXGyH94YSOMWtSNarZEFsZ2g7ZToTEwHj7rLlTx465mWbgJ2-XT-1_GDksdYWGfQQ8Ub_4r-Fd-KmJdnZxMG8TvqJAbPkrG6MpdHWriok8jIGq3F5ZqyQ1Htn2eSYMAY5VMdljEipQQ2Cua6Mnnl7BEp20nJXgU60dAeKRwC9pSYig1-c1TvhYNnjLUTWyGYaPdzTkJqbSgc8gU67156NESlmC7FIMAOr_nVjnL9SuvHpHzkW1EJvHRl1b5J9gv5ncU3PDQOuiU",
-        }
-    )
+    jwk = Jwk({
+        "kty": "RSA",
+        "n": "jp5HPGxg9n6u0HhJaNuE_hzQIPJ_AUfalQ5rw3gZpRNTCNSIQ2aNyIwzyt58zt-YUttb5OirSkhwuiTBm--U4jHJdg57Yy4m_r06ps-3w08HI8XWh6MSAeQwiovtGLSvQ76WGdkwTSeVcST_G9qy3osJdc9xTNwyrPyyfxDef6h8s6_v2GS-xXrKzYy78eoGMezw4-uetIWV5aVfuQ3QpkVo8hN2G0YKEAwRR_zbrzY7HUiCdvbdX-RglT94MOU-_QjUcP1rBYn1z8nOZ0uA_E9UbEnIMTR0IptepaD5NpqDnYFqm_FfOhDw5-hwMxuHw-rHYnvYY78bE4g3RrV8HGMe2CltveUy6VxR4PIJ0-OY7La9ycsSWMDUN5tuluyyM5PdLvwq1aQEzNFhnR0QXe4XRVrFEoSeyAZ7Wd4I4UYKzkPzXDifgPCwFIJNYtQ69q_dSAmCVq_hxwfAV4WkjX4mjb42YmEgKr8Siz3IQ2ZRN78KNClgdSVpJYAnmk37Y9kxhvQMerwiBWKFK8y9OZsoW0jukKJx6jOH2o8nUj630AU5QhjvHfrwS_SAp_leJTpP0o1IW0Hja_AvnaDJNhkn-Jt_zOtH4K2bc1ADbce3kWAxe9Q6XtBRPPYK8BVqUuIaWPHJ6ciHWnE1lvF8dO5oALpnmstb0LfiFimm9yk",
+        "e": "AQAB",
+        "d": "FRFeGhezgi5IIj0msQH-pTA58agI6XZFHLBO7Ib1GNzgLwWAZJ6Fctr9Oqp_uuquXI0Rh-D0DsrhNipAXIn5jymGJnWwtf_HHGn1PFeigIxP1HHBBXPqMNPV9N2DRptIacRBdauPFlKy4Y4yzllSA4x79waQKOe9Z68DqkAici7ATyX-ExQc11zSkSdJS00EIcNr-Wtg3C-Aq3YwzAw1pp5JyLrlv1UrHuA9fEom5Lzo4iRIO40vuh7pQprn5Sc0VRpFEbTp5p1Q7eNUpY8yjHMmmEGU_GnQfx0_D84WCoIsT6vixQsUw2XlxIhibLZUKbWowwxi9KcyN4Ivkjc0kF-DCkB-27abRlDzWRDbImipZ_GzVl54A4nyQ_oiY4iY3Yg7Fn49bUHfi2kn2WkoJbXe0L_Ju-7OKXGyH94YSOMWtSNarZEFsZ2g7ZToTEwHj7rLlTx465mWbgJ2-XT-1_GDksdYWGfQQ8Ub_4r-Fd-KmJdnZxMG8TvqJAbPkrG6MpdHWriok8jIGq3F5ZqyQ1Htn2eSYMAY5VMdljEipQQ2Cua6Mnnl7BEp20nJXgU60dAeKRwC9pSYig1-c1TvhYNnjLUTWyGYaPdzTkJqbSgc8gU67156NESlmC7FIMAOr_nVjnL9SuvHpHzkW1EJvHRl1b5J9gv5ncU3PDQOuiU",
+    })
 
     assert (
         RSAJwk.public(

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -443,8 +443,8 @@ def test_verify_signature_by_jwcrypto(
         signature_alg: the signature alg
 
     """
-    import jwcrypto.jwk  # type: ignore[import]
-    import jwcrypto.jws  # type: ignore[import]
+    import jwcrypto.jwk  # type: ignore[import-untyped]
+    import jwcrypto.jws  # type: ignore[import-untyped]
 
     jwk = jwcrypto.jwk.JWK(**verification_jwk)
     jws = jwcrypto.jws.JWS()

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -26,17 +26,15 @@ from jwskate import (
 
 
 def test_signed_jwt() -> None:
-    jwk = Jwk(
-        {
-            "kty": "EC",
-            "alg": "ES256",
-            "kid": "my_key",
-            "crv": "P-256",
-            "x": "WtjnvHG9b_IKBLn4QYTHz-AdoAiO_ork5LH1BL_5tyI",
-            "y": "C0YfOUDuCOvTCt7hAqO-f9z8_JdOnOPbfYmUk-RosHA",
-            "d": "EnGZlkoa4VUsnl72LcRRychNJ2FFknm_ph855tNuPZ8",
-        }
-    )
+    jwk = Jwk({
+        "kty": "EC",
+        "alg": "ES256",
+        "kid": "my_key",
+        "crv": "P-256",
+        "x": "WtjnvHG9b_IKBLn4QYTHz-AdoAiO_ork5LH1BL_5tyI",
+        "y": "C0YfOUDuCOvTCt7hAqO-f9z8_JdOnOPbfYmUk-RosHA",
+        "d": "EnGZlkoa4VUsnl72LcRRychNJ2FFknm_ph855tNuPZ8",
+    })
 
     jwt = Jwt(
         "eyJhbGciOiJFUzI1NiIsImtpZCI6Im15X2tleSJ9.eyJhY3IiOiIyIiwiYW1yIjpbInB3ZCIsIm90cCJdLCJhdWQiOiJjbGllbnRfaWQiLCJhdXRoX3RpbWUiOjE2MjkyMDQ1NjAsImV4cCI6MTYyOTIwNDYyMCwiaWF0IjoxNjI5MjA0NTYwLCJuYmYiOjE2MjkyMDQ1NjAsImlzcyI6Imh0dHBzOi8vbXlhcy5sb2NhbCIsIm5vbmNlIjoibm9uY2UiLCJzdWIiOiIxMjM0NTYifQ.RhLqE8VGBjIRag4w9ps1oUQlxumma1fQzFH2UTrMDCjW2iTGdqhkOjpzb5bdI6tkQRRP64IGP4_CBa2BR7p26Q"
@@ -241,53 +239,51 @@ def test_encrypted_jwt() -> None:
     )
     assert jwt.authentication_tag.to("b64u") == b"fiK51VwhsxJ-siBMR-YFiA"
 
-    jwk = Jwk(
-        {
-            "kty": "RSA",
-            "n": (
-                "sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1Wl"
-                "UzewbgBHod5pcM9H95GQRV3JDXboIRROSBigeC5yjU1hGzHHyXss8UDpre"
-                "cbAYxknTcQkhslANGRUZmdTOQ5qTRsLAt6BTYuyvVRdhS8exSZEy_c4gs_"
-                "7svlJJQ4H9_NxsiIoLwAEk7-Q3UXERGYw_75IDrGA84-lA_-Ct4eTlXHBI"
-                "Y2EaV7t7LjJaynVJCpkv4LKjTTAumiGUIuQhrNhZLuF_RJLqHpM2kgWFLU"
-                "7-VTdL1VbC2tejvcI2BlMkEpk1BzBZI0KQB0GaDWFLN-aEAw3vRw"
-            ),
-            "e": "AQAB",
-            "d": (
-                "VFCWOqXr8nvZNyaaJLXdnNPXZKRaWCjkU5Q2egQQpTBMwhprMzWzpR8Sxq"
-                "1OPThh_J6MUD8Z35wky9b8eEO0pwNS8xlh1lOFRRBoNqDIKVOku0aZb-ry"
-                "nq8cxjDTLZQ6Fz7jSjR1Klop-YKaUHc9GsEofQqYruPhzSA-QgajZGPbE_"
-                "0ZaVDJHfyd7UUBUKunFMScbflYAAOYJqVIVwaYR5zWEEceUjNnTNo_CVSj"
-                "-VvXLO5VZfCUAVLgW4dpf1SrtZjSt34YLsRarSb127reG_DUwg9Ch-Kyvj"
-                "T1SkHgUWRVGcyly7uvVGRSDwsXypdrNinPA4jlhoNdizK2zF2CWQ"
-            ),
-            "p": (
-                "9gY2w6I6S6L0juEKsbeDAwpd9WMfgqFoeA9vEyEUuk4kLwBKcoe1x4HG68"
-                "ik918hdDSE9vDQSccA3xXHOAFOPJ8R9EeIAbTi1VwBYnbTp87X-xcPWlEP"
-                "krdoUKW60tgs1aNd_Nnc9LEVVPMS390zbFxt8TN_biaBgelNgbC95sM"
-            ),
-            "q": (
-                "uKlCKvKv_ZJMVcdIs5vVSU_6cPtYI1ljWytExV_skstvRSNi9r66jdd9-y"
-                "BhVfuG4shsp2j7rGnIio901RBeHo6TPKWVVykPu1iYhQXw1jIABfw-MVsN"
-                "-3bQ76WLdt2SDxsHs7q7zPyUyHXmps7ycZ5c72wGkUwNOjYelmkiNS0"
-            ),
-            "dp": (
-                "w0kZbV63cVRvVX6yk3C8cMxo2qCM4Y8nsq1lmMSYhG4EcL6FWbX5h9yuv"
-                "ngs4iLEFk6eALoUS4vIWEwcL4txw9LsWH_zKI-hwoReoP77cOdSL4AVcra"
-                "Hawlkpyd2TWjE5evgbhWtOxnZee3cXJBkAi64Ik6jZxbvk-RR3pEhnCs"
-            ),
-            "dq": (
-                "o_8V14SezckO6CNLKs_btPdFiO9_kC1DsuUTd2LAfIIVeMZ7jn1Gus_Ff"
-                "7B7IVx3p5KuBGOVF8L-qifLb6nQnLysgHDh132NDioZkhH7mI7hPG-PYE_"
-                "odApKdnqECHWw0J-F0JWnUd6D2B_1TvF9mXA2Qx-iGYn8OVV1Bsmp6qU"
-            ),
-            "qi": (
-                "eNho5yRBEBxhGBtQRww9QirZsB66TrfFReG_CcteI1aCneT0ELGhYlRlC"
-                "tUkTRclIfuEPmNsNDPbLoLqqCVznFbvdB7x-Tl-m0l_eFTj2KiqwGqE9PZ"
-                "B9nNTwMVvH3VRRSLWACvPnSiwP8N5Usy-WRXS-V7TbpxIhvepTfE0NNo"
-            ),
-        }
-    )
+    jwk = Jwk({
+        "kty": "RSA",
+        "n": (
+            "sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1Wl"
+            "UzewbgBHod5pcM9H95GQRV3JDXboIRROSBigeC5yjU1hGzHHyXss8UDpre"
+            "cbAYxknTcQkhslANGRUZmdTOQ5qTRsLAt6BTYuyvVRdhS8exSZEy_c4gs_"
+            "7svlJJQ4H9_NxsiIoLwAEk7-Q3UXERGYw_75IDrGA84-lA_-Ct4eTlXHBI"
+            "Y2EaV7t7LjJaynVJCpkv4LKjTTAumiGUIuQhrNhZLuF_RJLqHpM2kgWFLU"
+            "7-VTdL1VbC2tejvcI2BlMkEpk1BzBZI0KQB0GaDWFLN-aEAw3vRw"
+        ),
+        "e": "AQAB",
+        "d": (
+            "VFCWOqXr8nvZNyaaJLXdnNPXZKRaWCjkU5Q2egQQpTBMwhprMzWzpR8Sxq"
+            "1OPThh_J6MUD8Z35wky9b8eEO0pwNS8xlh1lOFRRBoNqDIKVOku0aZb-ry"
+            "nq8cxjDTLZQ6Fz7jSjR1Klop-YKaUHc9GsEofQqYruPhzSA-QgajZGPbE_"
+            "0ZaVDJHfyd7UUBUKunFMScbflYAAOYJqVIVwaYR5zWEEceUjNnTNo_CVSj"
+            "-VvXLO5VZfCUAVLgW4dpf1SrtZjSt34YLsRarSb127reG_DUwg9Ch-Kyvj"
+            "T1SkHgUWRVGcyly7uvVGRSDwsXypdrNinPA4jlhoNdizK2zF2CWQ"
+        ),
+        "p": (
+            "9gY2w6I6S6L0juEKsbeDAwpd9WMfgqFoeA9vEyEUuk4kLwBKcoe1x4HG68"
+            "ik918hdDSE9vDQSccA3xXHOAFOPJ8R9EeIAbTi1VwBYnbTp87X-xcPWlEP"
+            "krdoUKW60tgs1aNd_Nnc9LEVVPMS390zbFxt8TN_biaBgelNgbC95sM"
+        ),
+        "q": (
+            "uKlCKvKv_ZJMVcdIs5vVSU_6cPtYI1ljWytExV_skstvRSNi9r66jdd9-y"
+            "BhVfuG4shsp2j7rGnIio901RBeHo6TPKWVVykPu1iYhQXw1jIABfw-MVsN"
+            "-3bQ76WLdt2SDxsHs7q7zPyUyHXmps7ycZ5c72wGkUwNOjYelmkiNS0"
+        ),
+        "dp": (
+            "w0kZbV63cVRvVX6yk3C8cMxo2qCM4Y8nsq1lmMSYhG4EcL6FWbX5h9yuv"
+            "ngs4iLEFk6eALoUS4vIWEwcL4txw9LsWH_zKI-hwoReoP77cOdSL4AVcra"
+            "Hawlkpyd2TWjE5evgbhWtOxnZee3cXJBkAi64Ik6jZxbvk-RR3pEhnCs"
+        ),
+        "dq": (
+            "o_8V14SezckO6CNLKs_btPdFiO9_kC1DsuUTd2LAfIIVeMZ7jn1Gus_Ff"
+            "7B7IVx3p5KuBGOVF8L-qifLb6nQnLysgHDh132NDioZkhH7mI7hPG-PYE_"
+            "odApKdnqECHWw0J-F0JWnUd6D2B_1TvF9mXA2Qx-iGYn8OVV1Bsmp6qU"
+        ),
+        "qi": (
+            "eNho5yRBEBxhGBtQRww9QirZsB66TrfFReG_CcteI1aCneT0ELGhYlRlC"
+            "tUkTRclIfuEPmNsNDPbLoLqqCVznFbvdB7x-Tl-m0l_eFTj2KiqwGqE9PZ"
+            "B9nNTwMVvH3VRRSLWACvPnSiwP8N5Usy-WRXS-V7TbpxIhvepTfE0NNo"
+        ),
+    })
 
     assert jwt.decrypt(jwk).parse_from("json") == {
         "iss": "joe",
@@ -567,17 +563,15 @@ def test_verifier(freezer: FrozenDateTimeFactory) -> None:
     issuer = "https://my.issuer.local"
     audience = "myaudience"
     subject = "mysubject"
-    private_jwk = Jwk(
-        {
-            "kty": "EC",
-            "crv": "P-256",
-            "alg": "ES256",
-            "kid": "MUBAl25sdPAIlnA_8-BnMcIe5e8LnlI5pHF6Zy-icvw",
-            "x": "ftZqn6yrLR_4AytQz8Q_badHRTQ2Vc6Eg46ICsMuuMM",
-            "y": "C4wIeHH0aIW5Tf1_EPnJkse-vcoDNd-kh8P6-Ci2MI8",
-            "d": "3vyhseJLd51ZXdlrCHAPH1uv5Bp9IvnA8UB92ksu4MU",
-        }
-    )
+    private_jwk = Jwk({
+        "kty": "EC",
+        "crv": "P-256",
+        "alg": "ES256",
+        "kid": "MUBAl25sdPAIlnA_8-BnMcIe5e8LnlI5pHF6Zy-icvw",
+        "x": "ftZqn6yrLR_4AytQz8Q_badHRTQ2Vc6Eg46ICsMuuMM",
+        "y": "C4wIeHH0aIW5Tf1_EPnJkse-vcoDNd-kh8P6-Ci2MI8",
+        "d": "3vyhseJLd51ZXdlrCHAPH1uv5Bp9IvnA8UB92ksu4MU",
+    })
     jwks = private_jwk.public_jwk().as_jwks()
 
     def suject_verifier(j: SignedJwt) -> None:

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -96,7 +96,7 @@ def test_unprotected() -> None:
 
 def test_jwt_signer_and_verifier(issuer: str, freezer: FrozenDateTimeFactory) -> None:
     audience = "some_audience"
-    signer = JwtSigner.with_random_key(issuer, alg="ES256")
+    signer = JwtSigner.with_random_key(issuer=issuer, alg="ES256")
     now = datetime.now(timezone.utc)
     jwt = signer.sign(subject="some_id", audience=audience, extra_claims={"foo": "bar"})
     assert isinstance(jwt, SignedJwt)


### PR DESCRIPTION
Next round of QA.
- made `InvalidSignature` exception more generic (to be used also for JWS tokens)
- add `JwsCompact.verify()` method
- ruff and mypy related fixes

A few breaking changes: 
- `JwtSigner.__init__()`, `JwtSigner.sign()` and `JweCompact.decrypt()` and now takes their optional parameters as kwarg only. JwkSigner takes a `key` param instead of `jwk` (for consistency with the rest of the API).
